### PR TITLE
Feat/add button component

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "./Header": "./dist/Header/index.js",
         "./Footer": "./dist/Footer.js",
         "./Display": "./dist/Display.js",
+        "./Button": "./dist/Button.js",
         "./Badge": "./dist/Badge.js",
         "./Alert": "./dist/Alert.js",
         "./Accordion": "./dist/Accordion.js"

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,0 +1,68 @@
+import React, { memo, forwardRef } from "react";
+// import { symToStr } from "tsafe/symToStr";
+import { fr } from "./lib";
+import { cx } from "./lib/tools/cx";
+
+// We make users import dsfr.css, so we don't need to import the scoped CSS
+// but in the future if we have a complete component coverage it
+// we could stop requiring users to import the hole CSS and only import on a
+// per component basis.
+import "./dsfr/component/button/button.css";
+
+const icons = ["fr-icon-checkbox-circle-line", "fr-icon-account-circle-fill"] as const;
+
+type IconType = typeof icons[number];
+
+type ButtonIcon = {
+    name: IconType;
+    position?: "left" | "right";
+};
+
+export type ButtonProps = {
+    label: string;
+    icon?: ButtonIcon;
+    priority?: "secondary" | "tertiary";
+    type?: "button" | "submit" | "reset";
+    href?: string;
+    target?: React.HTMLAttributeAnchorTarget;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    disabled?: boolean;
+    className?: string;
+    size?: ButtonProps.Size;
+};
+
+export namespace ButtonProps {
+    export type Size = "sm" | "lg";
+}
+
+export const Button = memo(
+    forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(props => {
+        const { icon, priority, type, onClick, href, disabled, className, size, label, target } =
+            props;
+
+        const buttonClassName = cx(
+            fr.cx("fr-btn"),
+            priority && fr.cx(`fr-btn--${priority}`),
+            size && fr.cx(`fr-btn--${size}`),
+            icon && cx(fr.cx(icon.name), icon.position && fr.cx(`fr-btn--icon-${icon.position}`)),
+            className
+        );
+        const Component =
+            "href" in props ? (
+                <a className={buttonClassName} href={href} target={target || "_self"}>
+                    {label}
+                </a>
+            ) : (
+                <button
+                    className={buttonClassName}
+                    type={type}
+                    onClick={onClick}
+                    disabled={disabled}
+                >
+                    {label}
+                </button>
+            );
+
+        return Component;
+    })
+);

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -9,36 +9,48 @@ import { cx } from "./lib/tools/cx";
 // per component basis.
 import "./dsfr/component/button/button.css";
 
-const icons = ["fr-icon-checkbox-circle-line", "fr-icon-account-circle-fill"] as const;
+// This is just an example, we should get types from .fr-icon-* list
+// const icons = ["fr-icon-checkbox-circle-line", "fr-icon-account-circle-fill"] as const;
+// type IconType = typeof icons[number];
 
-type IconType = typeof icons[number];
+type IconType = `fr-icon-${string}`;
 
 type ButtonIcon = {
     name: IconType;
     position?: "left" | "right";
 };
 
-export type ButtonProps = {
+type ButtonCommonProps = {
     label: string;
     icon?: ButtonIcon;
     priority?: "secondary" | "tertiary";
-    type?: "button" | "submit" | "reset";
-    href?: string;
-    target?: React.HTMLAttributeAnchorTarget;
-    onClick?: React.MouseEventHandler<HTMLButtonElement>;
-    disabled?: boolean;
     className?: string;
     size?: ButtonProps.Size;
 };
 
+export type ButtonProps = ButtonCommonProps & (ButtonProps.Anchor | ButtonProps.Button);
+
 export namespace ButtonProps {
     export type Size = "sm" | "lg";
+    export type Anchor = {
+        href: string | null;
+        target?: React.HTMLAttributeAnchorTarget;
+        disabled?: never;
+        type?: never;
+        onClick?: never;
+    };
+    export type Button = {
+        onClick?: React.MouseEventHandler<HTMLButtonElement>;
+        disabled?: boolean;
+        type?: "button" | "submit" | "reset";
+        href?: never;
+        target?: never;
+    };
 }
 
 export const Button = memo(
     forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(props => {
-        const { icon, priority, type, onClick, href, disabled, className, size, label, target } =
-            props;
+        const { icon, priority, className, size, label } = props;
 
         const buttonClassName = cx(
             fr.cx("fr-btn"),
@@ -49,15 +61,19 @@ export const Button = memo(
         );
         const Component =
             "href" in props ? (
-                <a className={buttonClassName} href={href} target={target || "_self"}>
+                <a
+                    className={buttonClassName}
+                    href={props.href ?? undefined}
+                    target={props.target || "_self"}
+                >
                     {label}
                 </a>
             ) : (
                 <button
                     className={buttonClassName}
-                    type={type}
-                    onClick={onClick}
-                    disabled={disabled}
+                    type={props.type}
+                    onClick={props.onClick}
+                    disabled={props.disabled}
                 >
                     {label}
                 </button>

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -2,6 +2,7 @@ import React, { memo, forwardRef } from "react";
 // import { symToStr } from "tsafe/symToStr";
 import { fr } from "./lib";
 import { cx } from "./lib/tools/cx";
+import type { FrIconClassName, RiIconClassName } from "./lib/generatedFromCss/classNames";
 
 // We make users import dsfr.css, so we don't need to import the scoped CSS
 // but in the future if we have a complete component coverage it
@@ -13,7 +14,7 @@ import "./dsfr/component/button/button.css";
 // const icons = ["fr-icon-checkbox-circle-line", "fr-icon-account-circle-fill"] as const;
 // type IconType = typeof icons[number];
 
-type IconType = `fr-icon-${string}`;
+type IconType = FrIconClassName | RiIconClassName;
 
 type ButtonIcon = {
     name: IconType;

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -7,7 +7,7 @@ const { meta, getStory } = getStoryFactory<ButtonProps>({
     sectionName,
     wrappedComponent: { Button },
     description: `
-- [See DSFR documentation](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/button)
+- [See DSFR documentation](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton)
 - [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/Button.tsx)`,
     "argTypes": {
         "priority": {

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -2,8 +2,6 @@ import { Button } from "../dist/Button";
 import type { ButtonProps } from "../dist/Button";
 import { sectionName } from "./sectionName";
 import { getStoryFactory } from "./getStory";
-import { assert } from "tsafe/assert";
-import type { Equals } from "tsafe";
 
 const { meta, getStory } = getStoryFactory<ButtonProps>({
     sectionName,
@@ -13,35 +11,37 @@ const { meta, getStory } = getStoryFactory<ButtonProps>({
 - [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/Button.tsx)`,
     "argTypes": {
         "priority": {
-            "options": (() => {
-                const priorities = ["secondary", "tertiary"] as const;
-
-                assert<Equals<typeof priorities[number] | undefined, ButtonProps["priority"]>>();
-
-                return priorities;
-            })(),
+            "options": ((): ButtonProps["priority"][] => ["secondary", "tertiary"])(),
             "control": { "type": "radio" }
         },
         "label": {
-            "description": `Required when the \`<Alert isSmall={false} />\` 
-      (which is the default if \`isSmall\` isn't specified).`
+            "description": `Required`
         },
         "href": {
-            "description": "Required when the `<Alert isSmall />`"
+            "description":
+                "If set, Button component will render a <a> tag, otherwise, it will render a <button>"
+        },
+        "type": {
+            "options": ((): ButtonProps["type"][] => ["button", "submit", "reset"])(),
+            "control": { "type": "radio" },
+            "description":
+                "Type can only be set on <button> element. If the Button component has no href, it will render a <button> element. If type prop is not set, it will render a type='submit' attribute (default value for a <button> element"
         },
         "onClick": {
-            "description": "If the modal should have a close button"
+            "description":
+                "onClick callback, can only be set if Button has no href prop set (to prevent onClick='window.open()' type behavior)"
         },
         "disabled": {
-            "description": "Called when the user clicks the close button"
+            "description":
+                "Can only be set if Button has no href prop set (disabled can't be set on <a> element)"
         },
         "target": {
-            "description": `If specified the \`<Alert />\` is in 
-          [controlled mode](https://reactjs.org/docs/forms.html#controlled-components)
-          this means that when the close button is clicked
-          the \`onClose()\` callback will be called but you are responsible
-          for setting \`isClosed\` to \`false\`, the \`<Alert />\` wont close itself.`,
-            "control": { "type": null }
+            "description": `Can only be set with a href attribute`,
+            "options": ((): ButtonProps["target"][] => ["_self", "_blank", "_parent", "_top"])()
+        },
+        "size": {
+            "description": `Can only be set with a href attribute`,
+            "options": ((): ButtonProps["size"][] => ["sm", "lg"])()
         }
     },
     "disabledProps": ["lang"]
@@ -50,25 +50,54 @@ const { meta, getStory } = getStoryFactory<ButtonProps>({
 export default meta;
 
 export const Default = getStory({
-    label: "Label bouton"
+    label: "Simple button"
 });
 
 export const ButtonSecondary = getStory({
     priority: "secondary",
-    label: "Label bouton secondaire"
+    label: "Simple button - secondary"
 });
 
 export const ButtonTertiary = getStory({
     priority: "tertiary",
-    label: "Label bouton tertiaire"
+    label: "Simple button - tertiary"
+});
+
+export const ButtonDisabled = getStory({
+    label: "Simple button - disabled",
+    disabled: true
+});
+
+export const ButtonWithIconDefault = getStory({
+    label: "Simple button with icon",
+    icon: {
+        name: "fr-icon-account-circle-fill"
+    }
+});
+
+export const ButtonWithIconLeft = getStory({
+    label: "Simple button with icon",
+    icon: {
+        name: "fr-icon-account-circle-fill",
+        position: "left"
+    }
+});
+
+export const ButtonWithIconRight = getStory({
+    label: "Simple button with icon",
+    icon: {
+        name: "fr-icon-account-circle-fill",
+        position: "right"
+    }
 });
 
 export const DefaultAnchorButton = getStory({
-    label: "Label bouton avec lien",
+    label: "Simple button - with href (anchor)",
     href: "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton"
 });
 
 export const DefaultAnchorButtonWithTargetBlank = getStory({
-    label: "Label bouton avec lien",
+    label: "Simple button - with href (anchor) and target _blank",
+    target: "_blank",
     href: "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton"
 });

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -1,0 +1,74 @@
+import { Button } from "../dist/Button";
+import type { ButtonProps } from "../dist/Button";
+import { sectionName } from "./sectionName";
+import { getStoryFactory } from "./getStory";
+import { assert } from "tsafe/assert";
+import type { Equals } from "tsafe";
+
+const { meta, getStory } = getStoryFactory<ButtonProps>({
+    sectionName,
+    wrappedComponent: { Button },
+    description: `
+- [See DSFR documentation](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/button)
+- [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/Button.tsx)`,
+    "argTypes": {
+        "priority": {
+            "options": (() => {
+                const priorities = ["secondary", "tertiary"] as const;
+
+                assert<Equals<typeof priorities[number] | undefined, ButtonProps["priority"]>>();
+
+                return priorities;
+            })(),
+            "control": { "type": "radio" }
+        },
+        "label": {
+            "description": `Required when the \`<Alert isSmall={false} />\` 
+      (which is the default if \`isSmall\` isn't specified).`
+        },
+        "href": {
+            "description": "Required when the `<Alert isSmall />`"
+        },
+        "onClick": {
+            "description": "If the modal should have a close button"
+        },
+        "disabled": {
+            "description": "Called when the user clicks the close button"
+        },
+        "target": {
+            "description": `If specified the \`<Alert />\` is in 
+          [controlled mode](https://reactjs.org/docs/forms.html#controlled-components)
+          this means that when the close button is clicked
+          the \`onClose()\` callback will be called but you are responsible
+          for setting \`isClosed\` to \`false\`, the \`<Alert />\` wont close itself.`,
+            "control": { "type": null }
+        }
+    },
+    "disabledProps": ["lang"]
+});
+
+export default meta;
+
+export const Default = getStory({
+    label: "Label bouton"
+});
+
+export const ButtonSecondary = getStory({
+    priority: "secondary",
+    label: "Label bouton secondaire"
+});
+
+export const ButtonTertiary = getStory({
+    priority: "tertiary",
+    label: "Label bouton tertiaire"
+});
+
+export const DefaultAnchorButton = getStory({
+    label: "Label bouton avec lien",
+    href: "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton"
+});
+
+export const DefaultAnchorButtonWithTargetBlank = getStory({
+    label: "Label bouton avec lien",
+    href: "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton"
+});


### PR DESCRIPTION
# Add Button component

[See DSFR doc](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton/)

Still needs improvements : we're checking that Button component has a href attribute. If so, it allows the use of target attr. Otherwise, the component will render a `<button>` element. As a button element, the component allows onClick, disabled, etc, to match HTML DOM types and forces the use of semantic and accessible tags to create hyperlinks. 
Not sure it's the best way to check it.