### PR TITLE
Change the import location for accordion.css

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -5,7 +5,7 @@ import { fr } from "./lib";
 import { cx } from "./lib/tools/cx";
 import { symToStr } from "tsafe/symToStr";
 import { useConstCallback } from "./lib/tools/powerhooks/useConstCallback";
-import "@gouvfr/dsfr/dist/component/accordion/accordion.css";
+import "./dsfr/component/accordion/accordion.css";
 
 export type AccordionProps = AccordionProps.Controlled | AccordionProps.Uncontrolled;
 


### PR DESCRIPTION
If an application does not have the `@gouvfr/dsfr` module installed, the following error is expected: 
```
./node_modules/@codegouvfr/react-dsfr/Accordion.js
Module not found: Can't resolve '@gouvfr/dsfr/component/accordion/accordion.css' in 'path\to\application\node_modules\@codegouvfr\react-dsfr'
```
Given that the css required is also in the `@codegouvfr/react-dsfr` module, we can locate this css locally in the module and prevent dependency errors. 

Signed-off-by: Matt Clark  <87824367+isMattCoding@users.noreply.github.com>