### PR TITLE
Button onClick can be optional

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -60,7 +60,7 @@ export namespace ButtonProps {
     };
     export type AsButton = {
         linkProps?: never;
-        onClick: React.MouseEventHandler<HTMLButtonElement>;
+        onClick?: React.MouseEventHandler<HTMLButtonElement>;
         nativeButtonProps?: Omit<
             React.DetailedHTMLProps<
                 React.ButtonHTMLAttributes<HTMLButtonElement>,


### PR DESCRIPTION
I came across an issue: I did want to use this component as a submit button form a form element, but its typing doesn't allow the usage as a <button> without a onClick prop.

I'm not sure passing onClick as optional is the best option, but even as a `<button type="button">`, I'm not sure we should constrain the user to pass a onClick prop.

Alternatively, we could pass onClick as optional if the button `type` attribute is `submit` or `reset`.