### PR TITLE
Input adjustements

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -11,6 +11,7 @@ export type InputProps = {
     className?: string;
     label: ReactNode;
     hintText?: ReactNode;
+    hideLabel?: boolean;
     /** default: false */
     disabled?: boolean;
     iconId?: FrIconClassName | RiIconClassName;
@@ -58,6 +59,7 @@ export const Input = memo(
             className,
             label,
             hintText,
+            hideLabel,
             disabled = false,
             iconId: iconId_props,
             classes = {},
@@ -109,9 +111,8 @@ export const Input = memo(
                 {...rest}
             >
                 <label
-                    className={cx(fr.cx("fr-label"), classes.label)}
+                    className={cx(fr.cx("fr-label", hideLabel && "fr-sr-only"), classes.label)}
                     htmlFor={inputId}
-                    aria-describedby="select-valid-desc-valid"
                 >
                     {label}
                     {hintText !== undefined && <span className="fr-hint-text">{hintText}</span>}

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -90,7 +90,7 @@ export const Input = memo(
             <div
                 className={cx(
                     fr.cx(
-                        "fr-input-group",
+                        nativeInputProps?.type === "file" ? "fr-upload-group" : "fr-input-group",
                         disabled && "fr-input-group--disabled",
                         (() => {
                             switch (state) {


### PR DESCRIPTION
Using this component, I thought some `<label>` related improvments could be useful:
- a `hideLabel` prop: not documented on DSFR docs, but we could allow users to provide a valid label but hide it (using sr-only to make it still readable by screen readers).
- removed aria-labelled attribute: as long as the label prop is mandatory and linked to the related input with htmlFor, I don't see why we should keep it.
- I added the support of the type file input (https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/ajout-de-fichier), wrapping it with a `fr-upload-group` : I was about creating a new component (to follow DSFR naming and docs), but it appears that Input and File are just the same, only the wrapper class is changing. Maybe we should create a File component that just wraps Input component?