### PR TITLE
doc: typo in module declaration of the router Link interface

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -26,7 +26,7 @@ import { startReactDsfr } from "@codegouvfr/react-dsfr/cra";
 </strong>});
 
 <strong>//Only in TypeScript projects
-</strong><strong>declare module "@codegouvfr/react-dsfr/cra" {
+</strong><strong>declare module "@codegouvfr/react-dsfr/spa" {
 </strong><strong>    interface RegisterLink { 
 </strong><strong>        Link: typeof Link;
 </strong><strong>    }


### PR DESCRIPTION
"@codegouvfr/react-dsfr/cra" doesn't exist 
```
Invalid module name in augmentation, module '@codegouvfr/react-dsfr/cra' cannot be found.
```

Signed-off-by: Ali Boulajine <abdelaliboulajine@gmail.com>