### PR TITLE
doc: typo on `useIsDark` in css-in-js page

### DIFF
--- a/css-in-js.md
+++ b/css-in-js.md
@@ -371,7 +371,7 @@ Consider using the [\<Display />](https://react-dsfr-components.etalab.studio/?p
 {% endhint %}
 
 ```tsx
-import { usIsDark } from "@codegouvfr/react-dsfr/useIsDark";
+import { useIsDark } from "@codegouvfr/react-dsfr/useIsDark";
 
 function MyComponent(){
 


### PR DESCRIPTION
Signed-off-by: Nicolas KOKLA <1872767+nkokla@users.noreply.github.com>