### PR TITLE
Feature / updated Select component

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -26,7 +26,7 @@ export type SelectProps<OptionValue> = {
     placeholder?: string;
 };
 export type GenericOption<OptionValue> = {
-    value: OptionValue | number | readonly string[] | undefined;
+    value: OptionValue;
     label: string;
     disabled?: boolean;
     hidden?: boolean;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -15,7 +15,6 @@ export type SelectProps = {
         React.SelectHTMLAttributes<HTMLSelectElement>,
         HTMLSelectElement
     >;
-    children: ReactNode;
     /** Default: false */
     disabled?: boolean;
     /** Default: "default" */
@@ -23,6 +22,16 @@ export type SelectProps = {
     /** The message won't be displayed if state is "default" */
     stateRelatedMessage?: ReactNode;
     style?: CSSProperties;
+    options: SelectOption[];
+    placeholder?: string;
+};
+
+export type SelectOption<T = string> = {
+    value: T | number | readonly string[] | undefined;
+    label: string;
+    disabled?: boolean;
+    hidden?: boolean;
+    // selected should not be handled directly by option, but as Select's value
 };
 
 /**
@@ -36,18 +45,29 @@ export const Select = memo(
             hint,
             nativeSelectProps,
             disabled = false,
-            children,
+            options,
             state = "default",
             stateRelatedMessage,
+            placeholder,
             style,
             ...rest
         } = props;
 
         assert<Equals<keyof typeof rest, never>>();
-
-        const selectId = `select-${useId()}`;
-        const stateDescriptionId = `select-${useId()}-desc`;
-
+        const elementId = nativeSelectProps.id || useId();
+        const selectId = `select-${elementId}`;
+        const stateDescriptionId = `select-${elementId}-desc`;
+        const displayedOptions = placeholder
+            ? [
+                  {
+                      label: placeholder,
+                      value: "",
+                      disabled: true
+                  },
+                  ...options
+              ]
+            : options;
+        console.log(displayedOptions);
         return (
             <div
                 className={cx(
@@ -83,7 +103,9 @@ export const Select = memo(
                     aria-describedby={stateDescriptionId}
                     disabled={disabled}
                 >
-                    {children}
+                    {displayedOptions.map(option => (
+                        <option {...option}>{option.label}</option>
+                    ))}
                 </select>
                 {state !== "default" && (
                     <p

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -7,11 +7,11 @@ import type { Equals } from "tsafe";
 import { fr } from "./fr";
 import { cx } from "./tools/cx";
 
-export type SelectProps = {
+export type SelectProps<OptionValue> = {
     className?: string;
     label: ReactNode;
     hint?: ReactNode;
-    nativeSelectProps: React.DetailedHTMLProps<
+    nativeSelectProps?: React.DetailedHTMLProps<
         React.SelectHTMLAttributes<HTMLSelectElement>,
         HTMLSelectElement
     >;
@@ -22,112 +22,119 @@ export type SelectProps = {
     /** The message won't be displayed if state is "default" */
     stateRelatedMessage?: ReactNode;
     style?: CSSProperties;
-    options: SelectOption[];
+    options: GenericOption<OptionValue>[];
     placeholder?: string;
 };
-
-export type SelectOption<T = string> = {
-    value: T | number | readonly string[] | undefined;
+export type GenericOption<OptionValue> = {
+    value: OptionValue | number | readonly string[] | undefined;
     label: string;
     disabled?: boolean;
     hidden?: boolean;
-    // selected should not be handled directly by option, but as Select's value
+    selected?: boolean;
 };
+
+type DefaultOptionValue = string | number | readonly string[] | undefined;
 
 /**
  * @see <https://react-dsfr-components.etalab.studio/?path=/docs/components-select>
  * */
 export const Select = memo(
-    forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
-        const {
-            className,
-            label,
-            hint,
-            nativeSelectProps,
-            disabled = false,
-            options,
-            state = "default",
-            stateRelatedMessage,
-            placeholder,
-            style,
-            ...rest
-        } = props;
+    forwardRef(
+        <T extends DefaultOptionValue>(
+            props: SelectProps<T>,
+            ref: React.LegacyRef<HTMLDivElement>
+        ) => {
+            const {
+                className,
+                label,
+                hint,
+                nativeSelectProps,
+                disabled = false,
+                options,
+                state = "default",
+                stateRelatedMessage,
+                placeholder,
+                style,
+                ...rest
+            } = props;
 
-        assert<Equals<keyof typeof rest, never>>();
-        const elementId = nativeSelectProps.id || useId();
-        const selectId = `select-${elementId}`;
-        const stateDescriptionId = `select-${elementId}-desc`;
-        const displayedOptions = placeholder
-            ? [
-                  {
-                      label: placeholder,
-                      value: "",
-                      disabled: true
-                  },
-                  ...options
-              ]
-            : options;
-        console.log(displayedOptions);
-        return (
-            <div
-                className={cx(
-                    fr.cx(
-                        "fr-select-group",
-                        disabled && "fr-select-group--disabled",
-                        (() => {
-                            switch (state) {
-                                case "error":
-                                    return "fr-select-group--error";
-                                case "success":
-                                    return "fr-select-group--valid";
-                                case "default":
-                                    return undefined;
-                            }
-                            assert<Equals<typeof state, never>>(false);
-                        })()
-                    ),
-                    className
-                )}
-                ref={ref}
-                style={style}
-                {...rest}
-            >
-                <label className={fr.cx("fr-label")} htmlFor={selectId}>
-                    {label}
-                    {hint !== undefined && <span className={fr.cx("fr-hint-text")}>{hint}</span>}
-                </label>
-                <select
-                    {...nativeSelectProps}
-                    className={cx(fr.cx("fr-select"), nativeSelectProps.className)}
-                    id={selectId}
-                    aria-describedby={stateDescriptionId}
-                    disabled={disabled}
-                >
-                    {displayedOptions.map(option => (
-                        <option {...option}>{option.label}</option>
-                    ))}
-                </select>
-                {state !== "default" && (
-                    <p
-                        id={stateDescriptionId}
-                        className={fr.cx(
+            assert<Equals<keyof typeof rest, never>>();
+            const elementId = nativeSelectProps?.id || useId();
+            const selectId = `select-${elementId}`;
+            const stateDescriptionId = `select-${elementId}-desc`;
+            const displayedOptions = placeholder
+                ? [
+                      {
+                          label: placeholder,
+                          value: "",
+                          disabled: true
+                      },
+                      ...options
+                  ]
+                : options;
+            return (
+                <div
+                    className={cx(
+                        fr.cx(
+                            "fr-select-group",
+                            disabled && "fr-select-group--disabled",
                             (() => {
                                 switch (state) {
                                     case "error":
-                                        return "fr-error-text";
+                                        return "fr-select-group--error";
                                     case "success":
-                                        return "fr-valid-text";
+                                        return "fr-select-group--valid";
+                                    case "default":
+                                        return undefined;
                                 }
                                 assert<Equals<typeof state, never>>(false);
                             })()
+                        ),
+                        className
+                    )}
+                    ref={ref}
+                    style={style}
+                    {...rest}
+                >
+                    <label className={fr.cx("fr-label")} htmlFor={selectId}>
+                        {label}
+                        {hint !== undefined && (
+                            <span className={fr.cx("fr-hint-text")}>{hint}</span>
                         )}
+                    </label>
+                    <select
+                        {...nativeSelectProps}
+                        className={cx(fr.cx("fr-select"), nativeSelectProps?.className)}
+                        id={selectId}
+                        aria-describedby={stateDescriptionId}
+                        disabled={disabled}
                     >
-                        {stateRelatedMessage}
-                    </p>
-                )}
-            </div>
-        );
-    })
+                        {displayedOptions.map(option => (
+                            <option {...option}>{option.label}</option>
+                        ))}
+                    </select>
+                    {state !== "default" && (
+                        <p
+                            id={stateDescriptionId}
+                            className={fr.cx(
+                                (() => {
+                                    switch (state) {
+                                        case "error":
+                                            return "fr-error-text";
+                                        case "success":
+                                            return "fr-valid-text";
+                                    }
+                                    assert<Equals<typeof state, never>>(false);
+                                })()
+                            )}
+                        >
+                            {stateRelatedMessage}
+                        </p>
+                    )}
+                </div>
+            );
+        }
+    )
 );
 
 Select.displayName = symToStr({ Select });

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,20 +1,25 @@
 "use client";
 
-import React, { memo, forwardRef, ReactNode, useId, type CSSProperties } from "react";
+import React, { memo, forwardRef, ReactNode, useId, type CSSProperties, ForwardedRef } from "react";
 import { symToStr } from "tsafe/symToStr";
 import { assert } from "tsafe/assert";
 import type { Equals } from "tsafe";
 import { fr } from "./fr";
 import { cx } from "./tools/cx";
 
-export type SelectProps<OptionValue> = {
+export type SelectProps<Options extends GenericOption<DefaultOptionValue>[]> = {
+    options: Options;
     className?: string;
     label: ReactNode;
     hint?: ReactNode;
-    nativeSelectProps?: React.DetailedHTMLProps<
-        React.SelectHTMLAttributes<HTMLSelectElement>,
-        HTMLSelectElement
-    >;
+    nativeSelectProps?: Omit<
+        React.DetailedHTMLProps<React.SelectHTMLAttributes<HTMLSelectElement>, HTMLSelectElement>,
+        "value" | "defaultValue"
+    > & {
+        // Overriding the type of value and defaultValue to only accept the value type of the options
+        value?: Options[number]["value"];
+        defaultValue?: Options[number]["value"];
+    };
     /** Default: false */
     disabled?: boolean;
     /** Default: "default" */
@@ -22,7 +27,6 @@ export type SelectProps<OptionValue> = {
     /** The message won't be displayed if state is "default" */
     stateRelatedMessage?: ReactNode;
     style?: CSSProperties;
-    options: GenericOption<OptionValue>[];
     placeholder?: string;
 };
 export type GenericOption<OptionValue> = {
@@ -38,105 +42,105 @@ type DefaultOptionValue = string | number | readonly string[] | undefined;
 /**
  * @see <https://react-dsfr-components.etalab.studio/?path=/docs/components-select>
  * */
-export const Select = memo(
-    forwardRef(
-        <T extends DefaultOptionValue>(
-            props: SelectProps<T>,
-            ref: React.LegacyRef<HTMLDivElement>
-        ) => {
-            const {
-                className,
-                label,
-                hint,
-                nativeSelectProps,
-                disabled = false,
-                options,
-                state = "default",
-                stateRelatedMessage,
-                placeholder,
-                style,
-                ...rest
-            } = props;
+export const Select = <T extends GenericOption<DefaultOptionValue>[]>(
+    props: SelectProps<T>,
+    ref: React.LegacyRef<HTMLDivElement>
+) => {
+    const {
+        className,
+        label,
+        hint,
+        nativeSelectProps,
+        disabled = false,
+        options,
+        state = "default",
+        stateRelatedMessage,
+        placeholder,
+        style,
+        ...rest
+    } = props;
 
-            assert<Equals<keyof typeof rest, never>>();
-            const elementId = nativeSelectProps?.id || useId();
-            const selectId = `select-${elementId}`;
-            const stateDescriptionId = `select-${elementId}-desc`;
-            const displayedOptions = placeholder
-                ? [
-                      {
-                          label: placeholder,
-                          value: "",
-                          disabled: true
-                      },
-                      ...options
-                  ]
-                : options;
-            return (
-                <div
-                    className={cx(
-                        fr.cx(
-                            "fr-select-group",
-                            disabled && "fr-select-group--disabled",
-                            (() => {
-                                switch (state) {
-                                    case "error":
-                                        return "fr-select-group--error";
-                                    case "success":
-                                        return "fr-select-group--valid";
-                                    case "default":
-                                        return undefined;
-                                }
-                                assert<Equals<typeof state, never>>(false);
-                            })()
-                        ),
-                        className
+    assert<Equals<keyof typeof rest, never>>();
+    const elementId = nativeSelectProps?.id || useId();
+    const selectId = `select-${elementId}`;
+    const stateDescriptionId = `select-${elementId}-desc`;
+    const displayedOptions = placeholder
+        ? [
+              {
+                  label: placeholder,
+                  value: "",
+                  disabled: true
+              },
+              ...options
+          ]
+        : options;
+    return (
+        <div
+            className={cx(
+                fr.cx(
+                    "fr-select-group",
+                    disabled && "fr-select-group--disabled",
+                    (() => {
+                        switch (state) {
+                            case "error":
+                                return "fr-select-group--error";
+                            case "success":
+                                return "fr-select-group--valid";
+                            case "default":
+                                return undefined;
+                        }
+                        assert<Equals<typeof state, never>>(false);
+                    })()
+                ),
+                className
+            )}
+            ref={ref}
+            style={style}
+            {...rest}
+        >
+            <label className={fr.cx("fr-label")} htmlFor={selectId}>
+                {label}
+                {hint !== undefined && <span className={fr.cx("fr-hint-text")}>{hint}</span>}
+            </label>
+            <select
+                {...nativeSelectProps}
+                className={cx(fr.cx("fr-select"), nativeSelectProps?.className)}
+                id={selectId}
+                aria-describedby={stateDescriptionId}
+                disabled={disabled}
+            >
+                {displayedOptions.map(option => (
+                    <option {...option}>{option.label}</option>
+                ))}
+            </select>
+            {state !== "default" && (
+                <p
+                    id={stateDescriptionId}
+                    className={fr.cx(
+                        (() => {
+                            switch (state) {
+                                case "error":
+                                    return "fr-error-text";
+                                case "success":
+                                    return "fr-valid-text";
+                            }
+                            assert<Equals<typeof state, never>>(false);
+                        })()
                     )}
-                    ref={ref}
-                    style={style}
-                    {...rest}
                 >
-                    <label className={fr.cx("fr-label")} htmlFor={selectId}>
-                        {label}
-                        {hint !== undefined && (
-                            <span className={fr.cx("fr-hint-text")}>{hint}</span>
-                        )}
-                    </label>
-                    <select
-                        {...nativeSelectProps}
-                        className={cx(fr.cx("fr-select"), nativeSelectProps?.className)}
-                        id={selectId}
-                        aria-describedby={stateDescriptionId}
-                        disabled={disabled}
-                    >
-                        {displayedOptions.map(option => (
-                            <option {...option}>{option.label}</option>
-                        ))}
-                    </select>
-                    {state !== "default" && (
-                        <p
-                            id={stateDescriptionId}
-                            className={fr.cx(
-                                (() => {
-                                    switch (state) {
-                                        case "error":
-                                            return "fr-error-text";
-                                        case "success":
-                                            return "fr-valid-text";
-                                    }
-                                    assert<Equals<typeof state, never>>(false);
-                                })()
-                            )}
-                        >
-                            {stateRelatedMessage}
-                        </p>
-                    )}
-                </div>
-            );
-        }
-    )
-);
+                    {stateRelatedMessage}
+                </p>
+            )}
+        </div>
+    );
+};
 
 Select.displayName = symToStr({ Select });
 
-export default Select;
+const ForwardedSelect = forwardRef(Select) as <T extends GenericOption<DefaultOptionValue>[]>(
+    props: SelectProps<T> & { ref?: ForwardedRef<HTMLDivElement> }
+) => ReturnType<typeof Select>;
+
+const MemoizedSelect = memo(ForwardedSelect) as typeof ForwardedSelect;
+
+export default MemoizedSelect;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -135,12 +135,13 @@ export const Select = <T extends GenericOption<DefaultOptionValue>[]>(
     );
 };
 
-Select.displayName = symToStr({ Select });
-
 const ForwardedSelect = forwardRef(Select) as <T extends GenericOption<DefaultOptionValue>[]>(
     props: SelectProps<T> & { ref?: ForwardedRef<HTMLDivElement> }
 ) => ReturnType<typeof Select>;
 
-const MemoizedSelect = memo(ForwardedSelect) as typeof ForwardedSelect;
+const MemoizedSelect = memo(ForwardedSelect) as typeof ForwardedSelect & {
+    displayName: string;
+};
+MemoizedSelect.displayName = symToStr({ Select });
 
 export default MemoizedSelect;

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Select, type SelectProps } from "../dist/Select";
 import { sectionName } from "./sectionName";
 import { getStoryFactory } from "./getStory";
@@ -21,21 +20,30 @@ import { Select } from "@codegouvfr/react-dsfr/Select";
 function MyComponent(){
 
     const [ value, setValue ] = useState("");
-
+    const options = [
+        {
+            value: "1",
+            label: "Option 1",
+        },
+        {
+            value: "2",
+            label: "Option 2",
+        },
+        {
+            value: "3",
+            label: "Option 3",
+        }
+    ]
     return (
         <Select
             label="Label"
             nativeSelectProps={{
                 onChange: event => setValue(event.target.value),
-                value
+                value: ""
             }}
-        >
-            <option value="" disabled hidden>Selectionnez une option</option>
-            <option value="1">Option 1</option>
-            <option value="2">Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4">Option 4</option>
-        </Select>
+            options={options}
+            placeholder="Selectionnez une option"
+        />
     );
 
 }
@@ -75,12 +83,12 @@ function MyComponent(){
             "description": "The props that you would pass to a native `<select />`",
             "control": { "type": null }
         },
-        "children": {
-            "description": "The `children` that you would give a native `<select />`",
-            "control": { "type": null }
-        },
         "disabled": {
             "control": { "type": "boolean" }
+        },
+        "placeholder": {
+            "description": "Adds a fake placeholder for the select element",
+            "control": { "type": "text" }
         },
         "hint": {
             "control": { "type": "text" }
@@ -89,7 +97,7 @@ function MyComponent(){
             "options": (() => {
                 const options = ["success", "error", "default"] as const;
 
-                assert<Equals<typeof options[number], NonNullable<SelectProps["state"]>>>();
+                assert<Equals<typeof options[number], NonNullable<SelectProps<typeof options[number]>["state"]>>>();
 
                 return options;
             })(),
@@ -105,20 +113,34 @@ function MyComponent(){
 
 export default meta;
 
+const defaultOptions = [
+    {
+        value: "1",
+        label: "Option 1"
+    },
+    {
+        value: "2",
+        label: "Option 2"
+    },
+    {
+        value: "3",
+        label: "Option 3"
+    }
+];
+
 export const Default = getStory({
     "label": "Label pour liste déroulante",
     "nativeSelectProps": {},
-    "children": (
-        <>
-            <option value="" selected disabled hidden>
-                Selectionnez une option
-            </option>
-            <option value="1">Option 1</option>
-            <option value="2">Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4">Option 4</option>
-        </>
-    )
+    "options": defaultOptions
+});
+
+export const DefaultWithPlaceholder = getStory({
+    "label": "Label pour liste déroulante",
+    "nativeSelectProps": {
+        "value": ""
+    },
+    "placeholder": "Sélectionnez une option",
+    "options": defaultOptions
 });
 
 export const ErrorState = getStory({
@@ -126,67 +148,36 @@ export const ErrorState = getStory({
     "state": "error",
     "stateRelatedMessage": "Texte d’erreur obligatoire",
     "nativeSelectProps": {},
-    "children": (
-        <>
-            <option value="" selected disabled hidden>
-                Selectionnez une option
-            </option>
-            <option value="1">Option 1</option>
-            <option value="2">Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4">Option 4</option>
-        </>
-    )
+    "options": defaultOptions
 });
 
 export const SuccessState = getStory({
     "label": "Label pour liste déroulante",
     "state": "success",
     "stateRelatedMessage": "Texte de validation",
-    "nativeSelectProps": {},
-    "children": (
-        <>
-            <option value="" selected disabled hidden>
-                Selectionnez une option
-            </option>
-            <option value="1">Option 1</option>
-            <option value="2">Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4">Option 4</option>
-        </>
-    )
+    "nativeSelectProps": {
+        "value": "2"
+    },
+    "placeholder": "Sélectionnez une option",
+    "options": defaultOptions
 });
 
 export const Disabled = getStory({
     "label": "Label pour liste déroulante",
     "disabled": true,
-    "nativeSelectProps": {},
-    "children": (
-        <>
-            <option value="" selected disabled hidden>
-                Selectionnez une option
-            </option>
-            <option value="1">Option 1</option>
-            <option value="2">Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4">Option 4</option>
-        </>
-    )
+    "nativeSelectProps": {
+        "value": ""
+    },
+    "placeholder": "Sélectionnez une option",
+    "options": defaultOptions
 });
 
 export const WithHint = getStory({
     "label": "Label pour liste déroulante",
     "hint": "Texte de description additionnel",
-    "nativeSelectProps": {},
-    "children": (
-        <>
-            <option value="" selected disabled hidden>
-                Selectionnez une option
-            </option>
-            <option value="1">Option 1</option>
-            <option value="2">Option 2</option>
-            <option value="3">Option 3</option>
-            <option value="4">Option 4</option>
-        </>
-    )
+    "nativeSelectProps": {
+        "value": ""
+    },
+    "placeholder": "Sélectionnez une option",
+    "options": defaultOptions
 });

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -4,7 +4,9 @@ import { getStoryFactory } from "./getStory";
 import { assert } from "tsafe/assert";
 import type { Equals } from "tsafe";
 
-const { meta, getStory } = getStoryFactory({
+const { meta, getStory } = getStoryFactory<
+    SelectProps<GenericOption<string | number | MyFakeValue>[]>
+>({
     sectionName,
     "wrappedComponent": { Select },
     "description": `
@@ -100,7 +102,7 @@ function MyComponent(){
                 assert<
                     Equals<
                         typeof options[number],
-                        NonNullable<SelectProps<typeof options[number]>["state"]>
+                        NonNullable<SelectProps<GenericOption<typeof options[number]>[]>["state"]>
                     >
                 >();
 
@@ -140,12 +142,12 @@ const myFakeValueSet = [
     "66a9d7ac-9b25-4e52-9de3-4b7238135b39"
 ] as const;
 
-const optionsWithTypedValues: GenericOption<typeof myFakeValueSet[number]>[] = myFakeValueSet.map(
-    fakeValue => ({
-        value: fakeValue,
-        label: fakeValue
-    })
-);
+type MyFakeValue = typeof myFakeValueSet[number];
+
+const optionsWithTypedValues: GenericOption<MyFakeValue>[] = myFakeValueSet.map(fakeValue => ({
+    value: fakeValue,
+    label: fakeValue
+}));
 
 export const Default = getStory({
     "label": "Label pour liste déroulante",

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -39,7 +39,7 @@ function MyComponent(){
             label="Label"
             nativeSelectProps={{
                 onChange: event => setValue(event.target.value),
-                value: ""
+                value,
             }}
             options={options}
             placeholder="Selectionnez une option"

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -128,6 +128,21 @@ const defaultOptions = [
     }
 ];
 
+const optionsWithTypedValues: SelectOption<number>[] = [
+    {
+        value: 1,
+        label: "Option 1"
+    },
+    {
+        value: 2,
+        label: "Option 2"
+    },
+    {
+        value: 3,
+        label: "Option 3"
+    }
+];
+
 export const Default = getStory({
     "label": "Label pour liste déroulante",
     "nativeSelectProps": {},
@@ -180,4 +195,13 @@ export const WithHint = getStory({
     },
     "placeholder": "Sélectionnez une option",
     "options": defaultOptions
+});
+
+export const TypedSelect = getStory({
+    "label": "Label pour liste déroulante avec valeurs d'options typesafe",
+    "placeholder": "Sélectionnez une option",
+    "options": optionsWithTypedValues,
+    "nativeSelectProps": {
+        "value": "2"
+    }
 });

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { Select, type SelectProps, type GenericOption } from "../dist/Select";
+import Select, { type SelectProps, type GenericOption } from "../dist/Select";
 import { sectionName } from "./sectionName";
 import { getStoryFactory } from "./getStory";
 import { assert } from "tsafe/assert";
@@ -133,27 +133,22 @@ const defaultOptions = [
     }
 ];
 
-type MyFakeValueSet =
-    | "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf"
-    | "1bda4f79-a199-40ce-985b-fa217809d568"
-    | "e91b2cac-48f6-4d60-b86f-ece02f076837"
-    | "66a9d7ac-9b25-4e52-9de3-4b7238135b39";
-
-const myFakeValueSet: MyFakeValueSet[] = [
+const myFakeValueSet = [
     "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf",
     "1bda4f79-a199-40ce-985b-fa217809d568",
     "e91b2cac-48f6-4d60-b86f-ece02f076837",
     "66a9d7ac-9b25-4e52-9de3-4b7238135b39"
-];
+] as const;
 
-const optionsWithTypedValues: GenericOption<MyFakeValueSet>[] = myFakeValueSet.map(fakeValue => ({
-    value: fakeValue,
-    label: fakeValue
-}));
+const optionsWithTypedValues: GenericOption<typeof myFakeValueSet[number]>[] = myFakeValueSet.map(
+    fakeValue => ({
+        value: fakeValue,
+        label: fakeValue
+    })
+);
 
 export const Default = getStory({
     "label": "Label pour liste déroulante",
-    "nativeSelectProps": {},
     "options": defaultOptions
 });
 
@@ -170,7 +165,6 @@ export const ErrorState = getStory({
     "label": "Label pour liste déroulante",
     "state": "error",
     "stateRelatedMessage": "Texte d’erreur obligatoire",
-    "nativeSelectProps": {},
     "options": defaultOptions
 });
 
@@ -210,6 +204,7 @@ export const TypedSelect = getStory({
     "placeholder": "Sélectionnez une option",
     "options": optionsWithTypedValues,
     "nativeSelectProps": {
-        "defaultValue": "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf"
+        "defaultValue": "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf",
+        "value": "dc9ee-7794-470e-9dcf-a8d1dd1a6fcf"
     }
 });

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { Select, type SelectProps } from "../dist/Select";
+import { Select, type SelectProps, type GenericOption } from "../dist/Select";
 import { sectionName } from "./sectionName";
 import { getStoryFactory } from "./getStory";
 import { assert } from "tsafe/assert";
@@ -97,7 +97,12 @@ function MyComponent(){
             "options": (() => {
                 const options = ["success", "error", "default"] as const;
 
-                assert<Equals<typeof options[number], NonNullable<SelectProps<typeof options[number]>["state"]>>>();
+                assert<
+                    Equals<
+                        typeof options[number],
+                        NonNullable<SelectProps<typeof options[number]>["state"]>
+                    >
+                >();
 
                 return options;
             })(),
@@ -128,7 +133,7 @@ const defaultOptions = [
     }
 ];
 
-const optionsWithTypedValues: SelectOption<number>[] = [
+const optionsWithTypedValues: GenericOption<number>[] = [
     {
         value: 1,
         label: "Option 1"

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -133,20 +133,23 @@ const defaultOptions = [
     }
 ];
 
-const optionsWithTypedValues: GenericOption<number>[] = [
-    {
-        value: 1,
-        label: "Option 1"
-    },
-    {
-        value: 2,
-        label: "Option 2"
-    },
-    {
-        value: 3,
-        label: "Option 3"
-    }
+type MyFakeValueSet =
+    | "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf"
+    | "1bda4f79-a199-40ce-985b-fa217809d568"
+    | "e91b2cac-48f6-4d60-b86f-ece02f076837"
+    | "66a9d7ac-9b25-4e52-9de3-4b7238135b39";
+
+const myFakeValueSet: MyFakeValueSet[] = [
+    "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf",
+    "1bda4f79-a199-40ce-985b-fa217809d568",
+    "e91b2cac-48f6-4d60-b86f-ece02f076837",
+    "66a9d7ac-9b25-4e52-9de3-4b7238135b39"
 ];
+
+const optionsWithTypedValues: GenericOption<MyFakeValueSet>[] = myFakeValueSet.map(fakeValue => ({
+    value: fakeValue,
+    label: fakeValue
+}));
 
 export const Default = getStory({
     "label": "Label pour liste déroulante",
@@ -207,6 +210,6 @@ export const TypedSelect = getStory({
     "placeholder": "Sélectionnez une option",
     "options": optionsWithTypedValues,
     "nativeSelectProps": {
-        "value": "2"
+        "defaultValue": "dc9d15ee-7794-470e-9dcf-a8d1dd1a6fcf"
     }
 });


### PR DESCRIPTION
While checking [this issue](https://github.com/codegouvfr/react-dsfr/issues/62) I noticed that the Select component could be more convenient to use. Based on what [we did on Immersion Facilitée](https://github.com/betagouv/immersion-facile/blob/dev/libs/react-design-system/src/immersionFacile/components/select/Select.tsx) and works a lot like component like `react-select`.

Basically, instead of using `<option>` as children, options are passed as as props (SelectOption<CustomValue>[]), and it can take a `placeholder` prop.

I find it more convenient IMO.