### PR TITLE
docs: pnpm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ yarn add @codegouvfr/react-dsfr
 ```bash
 npm install --save @codegouvfr/react-dsfr
 ```
+
+{% endtab %}
+
+{% tab title="pnpm" %}
+
+```bash
+pnpm add @codegouvfr/react-dsfr
+```
+
+And add this file to the root of your project, to enable pre & post scripts with pnpm:
+
+{% code title=".npmrc" %}
+
+```properties
+enable-pre-post-scripts=true
+```
+
+{% endcode %}
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
By default, pnpm is not implementing pre and post scripts so we have to enable them with the `.npmrc` file.
This PR implements documentation for installing the _react-dsfr_ library on projects using pnpm as a package manager.