### PR TITLE
Fix duplicated IDs issue while using multiple modals in a single page

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -59,7 +59,7 @@ const Modal = memo(
                 : [buttons_props];
 
         const { t } = useTranslation();
-const titleId= `fr-modal-title-${id}`;
+        const titleId= `fr-modal-title-${id}`;
         return (
             <dialog
                 aria-labelledby={titleId}

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -59,7 +59,7 @@ const Modal = memo(
                 : [buttons_props];
 
         const { t } = useTranslation();
-
+const titleId= `fr-modal-title-${id}`;
         return (
             <dialog
                 aria-labelledby={`fr-modal-title-${id}`}

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -62,7 +62,7 @@ const Modal = memo(
 const titleId= `fr-modal-title-${id}`;
         return (
             <dialog
-                aria-labelledby={`fr-modal-title-${id}`}
+                aria-labelledby={titleId}
                 role="dialog"
                 id={id}
                 className={cx(fr.cx("fr-modal", topAnchor && "fr-modal--top"), className)}

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -62,7 +62,7 @@ const Modal = memo(
 
         return (
             <dialog
-                aria-labelledby="fr-modal-title-modal-1"
+                aria-labelledby={`fr-modal-title-${id}`}
                 role="dialog"
                 id={id}
                 className={cx(fr.cx("fr-modal", topAnchor && "fr-modal--top"), className)}
@@ -96,7 +96,7 @@ const Modal = memo(
                                 </div>
                                 <div className={fr.cx("fr-modal__content")}>
                                     <h1
-                                        id="fr-modal-title-modal-1"
+                                        id={`fr-modal-title-${id}`}
                                         className={fr.cx("fr-modal__title")}
                                     >
                                         {iconId !== undefined && (

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -96,7 +96,7 @@ const titleId= `fr-modal-title-${id}`;
                                 </div>
                                 <div className={fr.cx("fr-modal__content")}>
                                     <h1
-                                        id={`fr-modal-title-${id}`}
+                                        id={titleId}
                                         className={fr.cx("fr-modal__title")}
                                     >
                                         {iconId !== undefined && (


### PR DESCRIPTION
Description: This pull request addresses the issue of duplicated IDs by modifying the code to use the modal ID for creating the H1 ID. This change ensures that the H1 ID remains unique, even when multiple modals are present on the same page.