### PR TITLE
feat: Add password functional block

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,7 @@ module.exports = {
     "stories": [
         "../stories/*.stories.mdx",
         "../stories/*.stories.@(ts|tsx)",
+        "../stories/blocks/*.stories.@(ts|tsx)"
     ],
     "addons": [
         "@storybook/addon-links",
@@ -10,9 +11,7 @@ module.exports = {
         "@storybook/addon-a11y"
     ],
     "core": {
-        "builder": "webpack5",
+        "builder": "webpack5"
     },
-    "staticDirs": [
-        "./static"
-    ]
+    "staticDirs": ["./static"]
 };

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
     },
     "dependencies": {
-        "tsafe": "^1.4.0"
+        "tsafe": "^1.6.0"
     },
     "devDependencies": {
         "@gouvfr/dsfr": "1.9.0",
@@ -131,6 +131,7 @@
         "./tss": "./dist/tss.js",
         "./tools/cx": "./dist/tools/cx.js",
         "./dsfr/*": "./dsfr/*",
+        "./block/*": "./block/*",
         "./ToggleSwitchGroup": "./dist/ToggleSwitchGroup.js",
         "./ToggleSwitch": "./dist/ToggleSwitch.js",
         "./Tile": "./dist/Tile.js",
@@ -146,7 +147,7 @@
         "./Pagination": "./dist/Pagination.js",
         "./Notice": "./dist/Notice.js",
         "./Modal": "./dist/Modal.js",
-        "./MainNavigation": "./dist/MainNavigation\\index.js",
+        "./MainNavigation": "./dist/MainNavigation/index.js",
         "./Input": "./dist/Input.js",
         "./Highlight": "./dist/Highlight.js",
         "./Header": "./dist/Header.js",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
         "./Summary": "./dist/Summary.js",
         "./Stepper": "./dist/Stepper.js",
         "./SkipLinks": "./dist/SkipLinks.js",
+        "./SideMenu": "./dist/SideMenu.js",
         "./Select": "./dist/Select.js",
         "./SearchBar": "./dist/SearchBar.js",
         "./RadioButtons": "./dist/RadioButtons.js",
@@ -145,7 +146,7 @@
         "./Pagination": "./dist/Pagination.js",
         "./Notice": "./dist/Notice.js",
         "./Modal": "./dist/Modal.js",
-        "./MainNavigation": "./dist/MainNavigation/index.js",
+        "./MainNavigation": "./dist/MainNavigation\\index.js",
         "./Input": "./dist/Input.js",
         "./Highlight": "./dist/Highlight.js",
         "./Header": "./dist/Header.js",
@@ -160,7 +161,6 @@
         "./Breadcrumb": "./dist/Breadcrumb.js",
         "./Badge": "./dist/Badge.js",
         "./Alert": "./dist/Alert.js",
-        "./Accordion": "./dist/Accordion.js",
-        "./SideMenu": "./dist/SideMenu.js"
+        "./Accordion": "./dist/Accordion.js"
     }
 }

--- a/src/blocks/PasswordInput.tsx
+++ b/src/blocks/PasswordInput.tsx
@@ -1,0 +1,198 @@
+import React, {
+    DetailedHTMLProps,
+    forwardRef,
+    InputHTMLAttributes,
+    memo,
+    ReactNode,
+    useId
+} from "react";
+import { assert, Equals } from "tsafe";
+import { symToStr } from "tsafe/symToStr";
+import { fr } from "../fr";
+import { createComponentI18nApi } from "../i18n";
+import type { InputProps } from "../Input";
+import { cx } from "../tools/cx";
+
+export type MessageGroup = {
+    state?: "success" | "error" | "default";
+    message: ReactNode;
+};
+
+export type PasswordInputProps = Omit<
+    InputProps.Common,
+    "state" | "stateRelatedMessage" | "iconId"
+> & {
+    classes?: Partial<
+        Record<"root" | "label" | "description" | "input" | "message" | "messageGroup", string>
+    >;
+    messagesGroup?: MessageGroup[];
+    nativeInputProps?: Omit<
+        DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+        "type"
+    >;
+};
+
+/**
+ * @see <https://react-dsfr-components.etalab.studio/?path=/docs/blocks-passwordinput
+ * */
+export const PasswordInput = memo(
+    forwardRef<HTMLDivElement, PasswordInputProps>((props, ref) => {
+        const {
+            className,
+            label,
+            hintText,
+            hideLabel,
+            disabled = false,
+            classes = {},
+            style,
+            messagesGroup,
+            nativeInputProps,
+            ...rest
+        } = props;
+
+        assert<Equals<keyof typeof rest, never>>();
+
+        const { t } = useTranslation();
+
+        const inputId = (function useClosure() {
+            const id = useId();
+
+            return nativeInputProps?.id ?? `password-${id}`;
+        })();
+        const containerId = `${inputId}-container`;
+        const togglePasswordShowId = `${inputId}-toggle-show`;
+        const messagesGroupId = `${inputId}-messages-group`;
+        const messageGroupId = `${inputId}-message-group`;
+
+        const hasError = messagesGroup?.find(({ state: messageState }) => messageState === "error");
+        const isSuccess = messagesGroup?.every(
+            ({ state: messageState }) => messageState === "success"
+        );
+
+        return (
+            <div
+                className={cx(
+                    fr.cx(
+                        "fr-password",
+                        disabled && "fr-input-group--disabled",
+                        hasError && "fr-input-group--error",
+                        isSuccess && "fr-input-group--valid"
+                    ),
+                    classes.root,
+                    className
+                )}
+                id={containerId}
+                style={style}
+                ref={ref}
+                {...rest}
+            >
+                <label
+                    className={cx(fr.cx("fr-label", hideLabel && "fr-sr-only"), classes.label)}
+                    htmlFor={inputId}
+                >
+                    {label}
+                    {hintText !== undefined && <span className="fr-hint-text">{hintText}</span>}
+                </label>
+                <div className={fr.cx("fr-input-wrap")}>
+                    <input
+                        {...nativeInputProps}
+                        className={cx(fr.cx("fr-password__input", "fr-input"), classes.input)}
+                        id={inputId}
+                        type="password"
+                        disabled={disabled || undefined}
+                        aria-describedby={messagesGroup && messagesGroupId}
+                    />
+                </div>
+                {messagesGroup && (
+                    <div
+                        className={cx(fr.cx("fr-messages-group"), classes.messageGroup)}
+                        id={messagesGroupId}
+                        aria-live="assertive"
+                    >
+                        <p className={(fr.cx("fr-message"), classes.message)} id={messageGroupId}>
+                            {t("your password must contain")}
+                        </p>
+                        {messagesGroup.map(({ state, message }, index) => (
+                            <p
+                                className={cx(
+                                    fr.cx(
+                                        "fr-message",
+                                        (() => {
+                                            switch (state) {
+                                                case "error":
+                                                    return "fr-message--error";
+                                                case "success":
+                                                    return "fr-message--valid";
+                                                default:
+                                                    return "fr-message--info";
+                                            }
+                                        })()
+                                    ),
+                                    classes.message
+                                )}
+                                id={`${messageGroupId}-${index}`}
+                            >
+                                {message}
+                            </p>
+                        ))}
+                    </div>
+                )}
+                <div
+                    className={fr.cx(
+                        "fr-password__checkbox",
+                        "fr-checkbox-group",
+                        "fr-checkbox-group--sm"
+                    )}
+                >
+                    <input
+                        aria-label={t("show password")}
+                        id={togglePasswordShowId}
+                        type="checkbox"
+                        disabled={disabled || undefined}
+                    />
+                    <label
+                        className={fr.cx("fr-password__checkbox", "fr-label")}
+                        htmlFor={togglePasswordShowId}
+                    >
+                        {t("show")}
+                    </label>
+                </div>
+            </div>
+        );
+    })
+);
+
+const { useTranslation, addPasswordInputTranslations } = createComponentI18nApi({
+    "componentName": symToStr({ PasswordInput }),
+    "frMessages": {
+        /* spell-checker: disable */
+        "show": "Afficher",
+        "show password": "Afficher le mot de passe",
+        "your password must contain": "Votre mot de passe doit contenir :"
+        /* spell-checker: enable */
+    }
+});
+
+addPasswordInputTranslations({
+    "lang": "en",
+    "messages": {
+        "show": "Show",
+        "show password": "Show password",
+        "your password must contain": "Your password must contain:"
+    }
+});
+
+addPasswordInputTranslations({
+    "lang": "es",
+    "messages": {
+        /* spell-checker: disable */
+        "show": "Mostrar",
+        "show password": "Mostrar contraseña",
+        "your password must contain": "Su contraseña debe contener:"
+        /* spell-checker: enable */
+    }
+});
+
+PasswordInput.displayName = symToStr({ PasswordInput });
+
+export default PasswordInput;

--- a/src/scripts/list-exports.ts
+++ b/src/scripts/list-exports.ts
@@ -29,6 +29,7 @@ const newExports = {
     "./tss": "./dist/tss.js",
     "./tools/cx": "./dist/tools/cx.js",
     "./dsfr/*": "./dsfr/*",
+    "./block/*": "./block/*",
     ...Object.fromEntries(
         fs
             .readdirSync(srcDirPath)
@@ -49,7 +50,7 @@ const newExports = {
                             continue;
                         }
 
-                        return [basename, relativePath];
+                        return [basename, relativePath.replace(new RegExp(/\\/, "g"), "/")];
                     }
 
                     return undefined;

--- a/stories/blocks/PasswordInput.stories.tsx
+++ b/stories/blocks/PasswordInput.stories.tsx
@@ -17,8 +17,7 @@ const { meta, getStory } = getStoryFactory({
             This is where you pass the \`name\` prop or \`onChange\` for example.`,
             "control": { "type": null }
         }
-    },
-    "disabledProps": ["lang"]
+    }
 });
 
 export default meta;
@@ -29,24 +28,28 @@ export const Default = getStory({
 
 export const WithHint = getStory({
     "label": "Mot de passe",
+    /* spell-checker: disable */
     "hintText": "Texte de description additionnel"
+    /* spell-checker: english */
 });
 
 export const WithMessagesGroup = getStory({
     "label": "Mot de passe",
-    "messagesGroup": [
+    "messages": [
+        /* spell-checker: disable */
         {
             "message": "12 caractères minimum",
-            "state": "default"
+            "severity": "info"
         },
         {
             "message": "1 caractère spécial minimum",
-            "state": "success"
+            "severity": "valid"
         },
         {
             "message": "1 chiffre minimum",
-            "state": "error"
+            "severity": "error"
         }
+        /* spell-checker: enabled */
     ]
 });
 

--- a/stories/blocks/PasswordInput.stories.tsx
+++ b/stories/blocks/PasswordInput.stories.tsx
@@ -1,0 +1,56 @@
+import PasswordInput from "../../dist/blocks/PasswordInput";
+import { getStoryFactory } from "../getStory";
+import { sectionName } from "./sectionName";
+
+const { meta, getStory } = getStoryFactory({
+    sectionName,
+    "wrappedComponent": { PasswordInput },
+    "description": `- [See DSFR documentation](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/mot-de-passe)
+- [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/blocks/PasswordInput.tsx)  `,
+    "argTypes": {
+        "disabled": {
+            "control": { "type": "boolean" }
+        },
+
+        "nativeInputProps": {
+            "description": `An object that is forwarded as props to te underlying native \`<input />\` element.  
+            This is where you pass the \`name\` prop or \`onChange\` for example.`,
+            "control": { "type": null }
+        }
+    },
+    "disabledProps": ["lang"]
+});
+
+export default meta;
+
+export const Default = getStory({
+    "label": "Mot de passe"
+});
+
+export const WithHint = getStory({
+    "label": "Mot de passe",
+    "hintText": "Texte de description additionnel"
+});
+
+export const WithMessagesGroup = getStory({
+    "label": "Mot de passe",
+    "messagesGroup": [
+        {
+            "message": "12 caractères minimum",
+            "state": "default"
+        },
+        {
+            "message": "1 caractère spécial minimum",
+            "state": "success"
+        },
+        {
+            "message": "1 chiffre minimum",
+            "state": "error"
+        }
+    ]
+});
+
+export const Disabled = getStory({
+    "label": "Mot de passe",
+    "disabled": true
+});

--- a/stories/blocks/sectionName.ts
+++ b/stories/blocks/sectionName.ts
@@ -1,0 +1,1 @@
+export const sectionName = "blocks";

--- a/yarn.lock
+++ b/yarn.lock
@@ -11133,10 +11133,15 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tsafe@^1.4.0, tsafe@^1.4.1:
+tsafe@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tsafe/-/tsafe-1.4.1.tgz#59cdad8ac41babf88e56dcd1a683ae2fb145d059"
   integrity sha512-3IDBalvf6SyvHFS14UiwCWzqdSdo+Q0k2J7DZyJYaHW/iraW9DJpaBKDJpry3yQs3o/t/A+oGaRW3iVt2lKxzA==
+
+tsafe@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/tsafe/-/tsafe-1.6.0.tgz#48a9bd0a4c43df43d289bdfc1d89f0d7fffbd612"
+  integrity sha512-wlUeRBnyN3EN2chXznpLm7vBEvJLEOziDU+MN6NRlD99AkwmXgtChNQhp+V97VyRa3Bp05IaL4Cocsc7JlyEUg==
 
 tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
Implémentation of the password functional block : https://www.systeme-de-design.gouv.fr/elements-d-interface/modeles-et-blocs-fonctionnels/demande-de-mot-de-passe

Not sure about the typing of the props. I based them from the InputProps but not sure that was a good idea. Let met know if you think it's better to have an independent typing, I will do the change.

The pre-commit hook   change the export on the package.json and not sure how it's works. I let the package.json on the pull request but let me know if I have to do something. It doesn't add the PasswordInput in the list but I think it's because I put it under a "blocks" folder. Same, let me know if I have to  move the component or change something
