### PR TITLE
fix: fix exports of blocks components

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "./tss": "./dist/tss.js",
         "./tools/cx": "./dist/tools/cx.js",
         "./dsfr/*": "./dsfr/*",
-        "./block/*": "./block/*",
+        "./blocks/*": "./dist/blocks/*",
         "./ToggleSwitchGroup": "./dist/ToggleSwitchGroup.js",
         "./ToggleSwitch": "./dist/ToggleSwitch.js",
         "./Tile": "./dist/Tile.js",

--- a/src/scripts/list-exports.ts
+++ b/src/scripts/list-exports.ts
@@ -29,7 +29,7 @@ const newExports = {
     "./tss": "./dist/tss.js",
     "./tools/cx": "./dist/tools/cx.js",
     "./dsfr/*": "./dsfr/*",
-    "./block/*": "./block/*",
+    "./blocks/*": "./dist/blocks/*",
     ...Object.fromEntries(
         fs
             .readdirSync(srcDirPath)


### PR DESCRIPTION
Just a little issue on the path to blocks folder path on the exports.