### PR TITLE
fix: fix exports of components blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
         "./tss": "./dist/tss.js",
         "./tools/cx": "./dist/tools/cx.js",
         "./dsfr/*": "./dsfr/*",
-        "./blocks/*": "./dist/blocks/*",
+        "./blocks/*": "./blocks/*",
         "./ToggleSwitchGroup": "./dist/ToggleSwitchGroup.js",
         "./ToggleSwitch": "./dist/ToggleSwitch.js",
         "./Tile": "./dist/Tile.js",

--- a/src/scripts/list-exports.ts
+++ b/src/scripts/list-exports.ts
@@ -29,7 +29,7 @@ const newExports = {
     "./tss": "./dist/tss.js",
     "./tools/cx": "./dist/tools/cx.js",
     "./dsfr/*": "./dsfr/*",
-    "./blocks/*": "./dist/blocks/*",
+    "./blocks/*": "./blocks/*",
     ...Object.fromEntries(
         fs
             .readdirSync(srcDirPath)


### PR DESCRIPTION
Hello, 

I do again a PR for the exports of blocks components. It seems to not work with the "/dist"  path. It works when I do a "yarn link-external" but not when I retrieve from npm package. When I build the project it says it doesn't find the PasswordInput module.

In the node_modules folder I have this package.json in the @codegouv/react-dsfr package:
![package.json](https://user-images.githubusercontent.com/9945898/227869761-67d24e88-6bd8-41c6-89fc-d57a4f673a4f.png)

Only blocks have the /dist folder so it's why I removed it from the exports but I am not sure of this, if it is the best way to do it, can you take a look, please ?

