### PR TITLE
fix/missing-class-on-notice-title

### DIFF
--- a/src/Notice.tsx
+++ b/src/Notice.tsx
@@ -126,7 +126,7 @@ export const Notice = memo(
             >
                 <div className="fr-container">
                     <div className="fr-notice__body">
-                        <p className={classes.title}>{title}</p>
+                        <p className={cx(fr.cx(`fr-notice__title`), classes.title)}>{title}</p>
                         {/* TODO: Use our button once we have one */}
                         {isClosable && (
                             <button


### PR DESCRIPTION
Adding the missing class "fr-notice__title" on the notice title as documented here : https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bandeau-d-information-importante