### PR TITLE
Add non breaking space before the end of li

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -230,6 +230,7 @@ export const Footer = memo(
                                         >
                                             {domain}
                                         </a>
+                                        &nbsp;
                                     </li>
                                 ))}
                             </ul>


### PR DESCRIPTION
When screen readers render these li, all of the links tend to render in one block. the `&nbsp;` helps keep them separated and shouldn't affect the style.