### PR TITLE
fix(Link): Link parsing from an UrlObject href

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -1,4 +1,5 @@
 import React, { type ReactNode, type DetailedHTMLProps, type AnchorHTMLAttributes } from "react";
+import { UrlObject, format } from "url";
 
 type HTMLAnchorProps = DetailedHTMLProps<
     AnchorHTMLAttributes<HTMLAnchorElement>,
@@ -18,12 +19,26 @@ let Link: (
     props: RegisteredLinkProps & { children: ReactNode }
 ) => ReturnType<React.FC> = props => <a {...props} />;
 
+/**
+ * Returns a url string from an Link href. If the link href is an UrlObject, it is converted to a string
+ *
+ * Return undefined if the href params is undefined
+ */
+function getUrlStringFromLinkHref(href: string | UrlObject | undefined): string | undefined {
+    if (href === undefined || typeof href === "string") {
+        return href;
+    }
+
+    // format is deprecated but didn't find a real alternative yet
+    return format(href);
+}
+
 export function setLink(params: { Link: typeof Link }): void {
     Link = props => {
         {
-            const { to, href, ...rest } = props as { to?: string; href?: string };
+            const { to, href, ...rest } = props as { to?: string; href?: string | UrlObject };
 
-            const target = to ?? href;
+            const target = to ?? getUrlStringFromLinkHref(href);
 
             mailto: {
                 if (target === undefined || !target.startsWith("mailto:")) {


### PR DESCRIPTION
In next js when a href is set with a UrlObject. It threw an error "target.startsWith is not a function".

For example, when using  a linkProps Button params like:
``` ts
linkProps: {
  href: {
    pathname: '/contact',
  },
},
```
 
it throw the error "target.startsWith is not a function"

When the href is an UrlObject, I format it to a string. I used the format function which is obsolete but I didn't find a good alternative yet and I don't have much time right now to look more, sorry. I do this PR if that can help you

Tests done:

```ts
linkProps: {
  href: {
    protocol: 'https',
    host: 'google.fr',
    pathname: '/contact',
  },
},

linkProps: {
  href: {
    protocol: 'mailto',
    hostname: 'dguezou@luminess.eu',
  },
},

linkProps: {
  href: '/contact'
},
```

