### PR TITLE
fix: add imageWidth & imageHeight properties on Tile

### DIFF
--- a/src/Tile.tsx
+++ b/src/Tile.tsx
@@ -15,6 +15,8 @@ export type TileProps = {
     desc?: ReactNode;
     imageUrl?: string;
     imageAlt?: string;
+    imageWidth?: string | number;
+    imageHeight?: string | number;
     grey?: boolean;
 
     /** make the whole tile clickable */
@@ -39,6 +41,8 @@ export const Tile = memo(
             desc,
             imageUrl,
             imageAlt,
+            imageWidth,
+            imageHeight,
             horizontal = false,
             grey = false,
             classes = {},
@@ -88,6 +92,8 @@ export const Tile = memo(
                             className={cx(fr.cx("fr-responsive-img"), classes.imgTag)}
                             src={imageUrl}
                             alt={imageAlt}
+                            width={imageWidth}
+                            height={imageHeight}
                         />
                     </div>
                 )) ||


### PR DESCRIPTION
The proposed change for the Tile component involves adding a feature to specify the width and height of the optional image.  I added imageWidth & imageHeight optionnal properties to follow the imageUrl & imageAlt pattern.

I'll make another suggestion : introduce an imageProps object, similar to the existing linkProps object, which would provide greater flexibility and control over the image properties. 

I am open to discussing this further.