### PR TITLE
Export link module

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
         "./useGdprStore": "./dist/useGdprStore.js",
         "./useColors": "./dist/useColors.js",
         "./useBreakpointsValues": "./dist/useBreakpointsValues.js",
+        "./link": "./dist/link.js",
         "./mui": "./dist/mui.js",
         "./tss": "./dist/tss.js",
         "./tools/cx": "./dist/tools/cx.js",

--- a/src/scripts/list-exports.ts
+++ b/src/scripts/list-exports.ts
@@ -28,6 +28,7 @@ const newExports = {
     "./useGdprStore": "./dist/useGdprStore.js",
     "./useColors": "./dist/useColors.js",
     "./useBreakpointsValues": "./dist/useBreakpointsValues.js",
+    "./link": "./dist/link.js",
     "./mui": "./dist/mui.js",
     "./tss": "./dist/tss.js",
     "./tools/cx": "./dist/tools/cx.js",


### PR DESCRIPTION
Hi !

I would like to import `setLink()` or `getLink()` from the link module to have access to the Link implementation but this module is not exported.

Is this ok ?