### PR TITLE
Set button types as "button" for modal open and close buttons

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -99,6 +99,7 @@ const Modal = memo(
                                         className={fr.cx("fr-btn--close", "fr-btn")}
                                         title={t("close")}
                                         aria-controls={id}
+                                        type="button"
                                     >
                                         {t("close")}
                                     </button>
@@ -231,7 +232,8 @@ export function createModal<Name extends string>(params: {
                 <Button
                     nativeButtonProps={{
                         ...modalNativeButtonProps,
-                        "id": hiddenControlButtonId
+                        "id": hiddenControlButtonId,
+                        "type": "button"
                     }}
                     className={fr.cx("fr-hidden")}
                 >


### PR DESCRIPTION
Hi there ! 
Default button type is "submit" in most browsers, this has fired "submit" events if the modal is embedded in a form for example.
Setting the type to "button" seems more in line with the intent in this case.

What do you think ? 