### PR TITLE
Remove counter for generating modal ids

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -198,8 +198,6 @@ addModalTranslations({
 
 export { addModalTranslations };
 
-let counter = 0;
-
 /** @see <https://react-dsfr-components.etalab.studio/?path=/docs/components-modal> */
 export function createModal<Name extends string>(params: {
     name: Name;
@@ -217,7 +215,7 @@ export function createModal<Name extends string>(params: {
     Record<`${Uncapitalize<Name>}ModalButtonProps`, ModalProps.ModalButtonProps> {
     const { name, isOpenedByDefault } = params;
 
-    const modalId = `${uncapitalize(name)}-modal-${counter++}`;
+    const modalId = `${uncapitalize(name)}-modal`;
 
     const modalNativeButtonProps = {
         "aria-controls": modalId,


### PR DESCRIPTION
Hi again :)

This one is more tricky.
During compilation of a next app with server component, sometime the createModal() call happens in 2 different contexts.

The result is a server rendering with `${uncapitalize(name)}-modal-0` and a client bundle with  `${uncapitalize(name)}-modal-1`

This has caused us a bug during hydration (aria-controls of the hidden modal control button are different), but also the button does not work in production at all since the aria-controls prop have a different id than the modal.

I am ok with the developers having the responsibility of putting unique modal names (as when using basic dsfr js)
But I am aware that this PR is a BC break for this component, what do you think ?
