### PR TITLE
Feature / Adjustments on Accordion

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -90,6 +90,7 @@ export const Accordion = memo(
                         aria-expanded={value}
                         aria-controls={accordionId}
                         onClick={onExtendButtonClick}
+                        type="button"
                     >
                         {label}
                     </button>


### PR DESCRIPTION
I'm trying to implement the Accordion component to make a multi-step form.

I noticed that right now, the `button` to toggle the Accordion has its default type (submit): when used in a form, it submits the form. I know this is a edge case, but I think it's less restrictive to use a `type="button"`.