### PR TITLE
fix(card): change card footer card to div to be semantic

### DIFF
--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -162,7 +162,7 @@ export const Card = memo(
                         </div>
                     </div>
                     {footer !== undefined && (
-                        <p className={cx(fr.cx("fr-card__footer"), classes.footer)}>{footer}</p>
+                        <div className={cx(fr.cx("fr-card__footer"), classes.footer)}>{footer}</div>
                     )}
                 </div>
                 {/* ensure we don't have an empty imageUrl string */}


### PR DESCRIPTION
The DSFR's cards footer are div, not paragraph.
Now ButtonsGroup can be added as footer without any semantic html error like "ul should be inside of p"