### PR TITLE
remove hidden attribute on placeholder plus fix typo in story

### DIFF
--- a/src/SelectNext.tsx
+++ b/src/SelectNext.tsx
@@ -134,8 +134,7 @@ function NonMemoizedNonForwardedSelect<T extends SelectProps.Option[]>(
                         "label": placeholder === undefined ? t("select an option") : placeholder,
                         "selected": true,
                         "value": "",
-                        "disabled": true,
-                        "hidden": true
+                        "disabled": true
                     },
                     ...options
                 ].map((option, index) => (

--- a/stories/SelectNext.stories.tsx
+++ b/stories/SelectNext.stories.tsx
@@ -6,7 +6,7 @@ import type { Equals } from "tsafe";
 
 const { meta, getStory } = getStoryFactory<SelectProps<SelectProps.Option[]>>({
     sectionName,
-    "wrappedComponent": { "SelectNex": Select },
+    "wrappedComponent": { "SelectNext": Select },
     "description": `
 - [See DSFR documentation](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bandeau-d-information-importante)
 - [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/Notice.tsx)


### PR DESCRIPTION
I just removed the hidden attribut in the placeholder because in chrome the first option was looking like it's selected whilee it's not.

previous behavior:
<img width="1087" alt="image" src="https://github.com/codegouvfr/react-dsfr/assets/104081060/17c66c36-d02d-42fa-a44e-9066b132283f">

actual behavior:
<img width="1064" alt="image" src="https://github.com/codegouvfr/react-dsfr/assets/104081060/89fd14cb-513a-4542-ab56-921d8ab5aa2a">

