### PR TITLE
fix: optional title for alert components

### DIFF
--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -158,7 +158,7 @@ export const Alert = memo(
                 ref={ref}
                 {...rest}
             >
-                {title && (
+                {title !== undefined && (
                     <HtmlTitleTag className={cx(fr.cx("fr-alert__title"), classes.title)}>
                         {title}
                     </HtmlTitleTag>

--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -158,9 +158,11 @@ export const Alert = memo(
                 ref={ref}
                 {...rest}
             >
-                <HtmlTitleTag className={cx(fr.cx("fr-alert__title"), classes.title)}>
-                    {title}
-                </HtmlTitleTag>
+                {title && (
+                    <HtmlTitleTag className={cx(fr.cx("fr-alert__title"), classes.title)}>
+                        {title}
+                    </HtmlTitleTag>
+                )}
                 <p className={classes.description}>{description}</p>
                 {isClosable && (
                     <button


### PR DESCRIPTION
Remove empty title tags in small size components when the title is not provided.
![CleanShot 2023-06-08 at 10 51 44 2@2x](https://github.com/codegouvfr/react-dsfr/assets/709456/3853ac42-c61f-48bf-bc64-01191d873aff)
