### PR TITLE
feat: adding keyboard navigation to Tabs component for accessibility …

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -123,24 +123,13 @@ export const Tabs = memo(
                     targetIndex = tabs.length - 1;
                     break;
             }
-            setSelectedTabIndex(targetIndex);
+            buttonRefs.current[targetIndex]?.click();
         };
 
         React.useEffect(() => {
             const targetTabButton = buttonRefs.current[selectedTabIndex];
             if (targetTabButton) {
                 targetTabButton.focus();
-            }
-        }, [selectedTabIndex]);
-
-        React.useEffect(() => {
-            if (selectedTabId === undefined) {
-                onTabChange?.({
-                    tabIndex: selectedTabIndex,
-                    "tab": tabs[selectedTabIndex]
-                });
-            } else {
-                onTabChange(tabs[selectedTabIndex].tabId);
             }
         }, [selectedTabIndex]);
 


### PR DESCRIPTION
Hello team,   

A small addition to the Tab component in order to activate keyboard navigation to fit accessibility requirements.  

I applied a similar logic from this file : https://github.com/GouvernementFR/dsfr/blob/main/src/component/tab/script/tab/tabs-group.js

Hope this will meet the standards 