### PR TITLE
fix: SelectNext - wrong FR spelling

### DIFF
--- a/src/SelectNext.tsx
+++ b/src/SelectNext.tsx
@@ -174,9 +174,7 @@ export default Select;
 const { useTranslation, addSelectTranslations } = createComponentI18nApi({
     "componentName": symToStr({ Select }),
     "frMessages": {
-        /* spell-checker: disable */
-        "select an option": "Selectioner une option"
-        /* spell-checker: enable */
+        "select an option": "Sélectionner une option"
     }
 });
 


### PR DESCRIPTION
Hello team,

thanks for this amazing work.

Just a PR to fix a wrong default spelling in SelectNext component.

Regards,