### PR TITLE
fix(Input): no type on textarea

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -156,7 +156,7 @@ export const Input = memo(
                             )}
                             disabled={disabled || undefined}
                             aria-describedby={messageId}
-                            type={nativeInputProps?.type ?? "text"}
+                            type={textArea ? undefined : nativeInputProps?.type ?? "text"}
                             id={inputId}
                         />
                     );


### PR DESCRIPTION
Sets the `type` property to `undefined`  when the Input is a `<textarea>`.
`type` is left unchanged for `<input>` elements.

See issue #159