### PR TITLE
chore(docs): add tips to see new icons && typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Also you must configure it so it uses `node_modules` (sorry)
 Demo setup in production here: [https://vite-demo.react-dsfr.fr/](https://vite-demo.react-dsfr.fr/)
 {% endembed %}
 
-Add theses three scipts to your `package.json`:
+Add these three scripts to your `package.json`:
 
 <pre class="language-json" data-title="package.json"><code class="lang-json">"scripts": {
 <strong>    "postinstall": "copy-dsfr-to-public",
@@ -102,7 +102,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 );
 </code></pre>
 
-You're all set! Next step for you is to setup de integration with your routing library (react-router for example)
+You're all set! Next step for you is to setup the integration with your routing library (react-router for example).
 
 {% content-ref url="routing.md" %}
 [routing.md](routing.md)
@@ -120,7 +120,7 @@ You are in this case if you have a `app/` directory at the root of your project.
 Starter project in prod here: [https://next-demo.react-dsfr.fr/](https://next-demo.react-dsfr.fr/)
 {% endembed %}
 
-Despite the setup process not being as streamlined as one might hope due to certain Next specific limitations, the library is fully compatible with Next.js App Router ([see demo](https://next-demo.react-dsfr.fr/)). Most component featured in this toolkit are [RSC ready](https://nextjs.org/docs/getting-started/react-essentials#server-components), thoses that are not are labeled using [the `"use client"` directive](https://nextjs.org/docs/getting-started/react-essentials#the-use-client-directive).
+Despite the setup process not being as streamlined as one might hope due to certain Next specific limitations, the library is fully compatible with Next.js App Router ([see demo](https://next-demo.react-dsfr.fr/)). Most component featured in this toolkit are [RSC ready](https://nextjs.org/docs/getting-started/react-essentials#server-components), those that are not are labeled using [the `"use client"` directive](https://nextjs.org/docs/getting-started/react-essentials#the-use-client-directive).
 
 ```bash
 yarn add --dev sass
@@ -327,7 +327,7 @@ The create-react-app project is no longer being maintained. If you are starting 
 See demo setup in production here: [https://cra-demo.react-dsfr.fr/](https://cra-demo.react-dsfr.fr/)
 {% endembed %}
 
-Add theses three scipts to your `package.json`:
+Add these three scripts to your `package.json`:
 
 <pre class="language-json" data-title="package.json"><code class="lang-json">"scripts": {
     ...
@@ -387,13 +387,13 @@ You're all set! Next step for you is to setup de integration with your routing l
 {% endtab %}
 
 {% tab title="Other" %}
-Your framwork isn't supported? let's [get in touch](https://github.com/codegouvfr/dsfr-react)!
+Your framework isn't supported? Let's [get in touch](https://github.com/codegouvfr/dsfr-react)!
 {% endtab %}
 {% endtabs %}
 
 ### Avoiding or flash of unstyled text (FOUT)
 
-You can avoid having a flash of unstiled text by preloading the font variant used on your homepage.(look in the network tab of your browser dev tool what are the font downloaded initially).
+You can avoid having a flash of unstyled text by preloading the font variant used on your homepage (look in the network tab of your browser dev tools what are the font downloaded initially).
 
 {% tabs %}
 {% tab title="Create React App" %}

--- a/components.md
+++ b/components.md
@@ -10,9 +10,9 @@ What to do if you want to customize the components beyond what the props allow.
 
 #### The `classes` property
 
-Every component or react-dsfr accepts an optional classes property that enables you to customize their look at a fine grained level.
+Every component of react-dsfr accepts an optional `classes` property that enables you to customize their look at a fine grained level.
 
-<figure><img src=".gitbook/assets/image (5).png" alt=""><figcaption><p>Availables classes on the Alert components</p></figcaption></figure>
+<figure><img src=".gitbook/assets/image (5).png" alt=""><figcaption><p>Available classes on the Alert components</p></figcaption></figure>
 
 <figure><img src=".gitbook/assets/image (8) (1).png" alt=""><figcaption><p>We add a 5v margin-top to the close button</p></figcaption></figure>
 

--- a/css-in-js.md
+++ b/css-in-js.md
@@ -4,7 +4,7 @@ description: Compatibility with solutions like styled-components, emotion and TS
 
 # 💅 CSS in JS
 
-At build time `react-dsfr` parses the official [dsfr.css](https://unpkg.com/browse/@gouvfr/dsfr/dist/dsfr/dsfr.css) files and spits out a typed JavaScript representation of the DSFR. In particular, its colors [options](https://unpkg.com/browse/@codegouvfr/react-dsfr@0.24.0/src/fr/generatedFromCss/getColorOptions.ts) and [decisions](https://unpkg.com/browse/@codegouvfr/react-dsfr/src/fr/generatedFromCss/getColorDecisions.ts), the [spacing stystem](https://unpkg.com/browse/@codegouvfr/react-dsfr/src/fr/generatedFromCss/spacing.ts) and the [breakpoints values](https://unpkg.com/browse/@codegouvfr/react-dsfr/src/fr/generatedFromCss/breakpoints.ts).
+At build time `react-dsfr` parses the official [dsfr.css](https://unpkg.com/browse/@gouvfr/dsfr/dist/dsfr/dsfr.css) files and spits out a typed JavaScript representation of the DSFR. In particular, its colors [options](https://unpkg.com/browse/@codegouvfr/react-dsfr@0.24.0/src/fr/generatedFromCss/getColorOptions.ts) and [decisions](https://unpkg.com/browse/@codegouvfr/react-dsfr/src/fr/generatedFromCss/getColorDecisions.ts), the [spacing system](https://unpkg.com/browse/@codegouvfr/react-dsfr/src/fr/generatedFromCss/spacing.ts) and the [breakpoints values](https://unpkg.com/browse/@codegouvfr/react-dsfr/src/fr/generatedFromCss/breakpoints.ts).
 
 This enables to write DSFR compliant CSS in JS code, since we are able to expose function that are the equivalent of the DSFR utility classes.
 
@@ -62,7 +62,7 @@ Dynamic CSS-in-TS syle engine
 {% endembed %}
 
 ```bash
-# Deppendencies to install even if never user directly:  
+# Dependencies to install even if never used directly:
 yarn add tss-react @emotion/react
 ```
 
@@ -156,7 +156,7 @@ Advantages of tss-react over other CSS in JS solutions
 {% embed url="https://styled-components.com/" %}
 
 {% hint style="info" %}
-[styled-component](https://styled-components.com/) and [@emotion/styled](https://emotion.sh/docs/styled) are equivalent API wise so I give the example with Emotion since it has a better MUI integration.
+[styled-component](https://styled-components.com/) and [@emotion/styled](https://emotion.sh/docs/styled) are equivalent API-wise so I give the example with Emotion since it has a better MUI integration.
 {% endhint %}
 
 {% code title="index.tsx" %}
@@ -328,7 +328,7 @@ This is made possible by [options.ts](https://unpkg.com/browse/@codegouvfr/react
 {% endhint %}
 
 {% hint style="success" %}
-The is [a tool](https://components.react-dsfr.codegouv.studio/?path=/docs/%25F0%259F%258E%25A8-color-resolver--page) at your disposal to help you pick your colors.
+There is [a tool](https://components.react-dsfr.codegouv.studio/?path=/docs/%F0%9F%8E%A8-color-helper--page) at your disposal to help you pick your colors.
 {% endhint %}
 
 The React agnostic way:
@@ -423,8 +423,8 @@ function MyComponent(){
     const { isDark, setIsDark } = useIsDark();
     
     //isDark is a boolean that is true if the App is currently in dark mode.
-    
-    //Calling setIsDark(true) will swith the app in dark mode. 
+
+    //Calling setIsDark(true) will switch the app in dark mode.
     //calling setIsDark("system") will set to whatever mode is signaled as prefered
     //by the user browser
 
@@ -470,7 +470,7 @@ Be carefull though, favor using `fr.breakpoints` over client size mesurement and
 
 On the backend you can't know ahead of time the size of the screen of your users so this kind of approach will result in a flickering in SSR setups.
 
-For example, your backend has no clue the size of the device making the request so it renders for a 1080p screen but the device making the request was, in fact, an iPhone and the first print is fully broken, the app becomes usable only after hydratation.
+For example, your backend has no clue the size of the device making the request so it renders for a 1080p screen but the device making the request was, in fact, an iPhone and the first print is fully broken, the app becomes usable only after hydration.
 
 Long story short, use this only if you are building an SPA.
 {% endhint %}

--- a/i18n.md
+++ b/i18n.md
@@ -2,7 +2,7 @@
 
 DSFR components contain hard coded strings.
 
-Theses strings can be switched from a langage to another with a provider.
+These strings can be switched from a langage to another with a provider.
 
 ![When lang="en"](https://user-images.githubusercontent.com/6702424/202221151-9e04dd77-da52-4ce7-b1b1-5bb653addf50.png) ![When lang="fr"](https://user-images.githubusercontent.com/6702424/202221309-b11b89a7-4893-442b-ab2a-92f85177ba69.png)
 
@@ -90,7 +90,7 @@ const { withDsfr, dsfrDocumentApi } = createNextDsfrIntegrationApi({
 {% endtab %}
 
 {% tab title="Other i18n library" %}
-It's up you you to remplace in the following example to remplace `"fr"` by the desired locale using to tooling exposed by your i18n library.
+It's up to you to replace in the following example `"fr"` by the desired locale using to tooling exposed by your i18n library.
 
 ```tsx
 startDsfrReact({ 
@@ -103,9 +103,9 @@ startDsfrReact({
 
 
 
-### Adding translations or overwriting defaut text
+### Adding translations or overwriting default text
 
-The components usualy come with one or two translations by default, typically english (`en`), spanish (`es`) and sometime german (`de`). [Illustration with the \<DarkModeSwitch /> component](https://github.com/codegouvfr/react-dsfr/blob/e8b78dd5ad069a322fbcc34b34b25d4ac8214e34/src/DarkModeSwitch.tsx#L162-L199).
+The components usually come with one or two translations by default, typically english (`en`), spanish (`es`) and sometime german (`de`). [Illustration with the \<DarkModeSwitch /> component](https://github.com/codegouvfr/react-dsfr/blob/e8b78dd5ad069a322fbcc34b34b25d4ac8214e34/src/DarkModeSwitch.tsx#L162-L199).
 
 You can add translation for extra language on a component basis, like so:
 

--- a/icons.md
+++ b/icons.md
@@ -4,6 +4,10 @@
 
 Icons just work, you can copy paste any code from [the dsfr documentation](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icone) and expect things to work.
 
+{% hint style="info" %}
+Whenever you add a new icon to your project, restart your local server. This will launch the `only_include_used_icons` script configured in the [Initial setup](./) (else you'll see a blue square instead of your icon).
+{% endhint %}
+
 ```jsx
 import { fr } from "@codegrouvfr/react-dsfr";
 import { Button } from "@codegouvfr/react-dsfr/Button";
@@ -47,7 +51,7 @@ It's done automatically for you.
 
 The `dsfr/utility/icons/icons.css` file is patched by the `only_include_used_icons` script.
 
-This script look at your code to see what icons you are actually using then proceed to patch `icon.css` file so that only thoses icons are defined.
+This script looks at your code to see what icons you are actually using then proceed to patch `icon.css` file so that only those icons are defined.
 {% endhint %}
 
 The `fr.cx()` utility is also handy for autocompleting the icons that are supported:

--- a/mui.md
+++ b/mui.md
@@ -81,7 +81,7 @@ In Next.js setup, on initial page load you may experience a few frames where MUI
 
 <figure><img src=".gitbook/assets/image (8).png" alt=""><figcaption><p>After idratation it switches to dark mode</p></figcaption></figure>
 
-You can eradicate theses few frames on subsequent page load by telling Next.js to perform SSR in the correct color scheme for the user:
+You can eradicate these few frames on subsequent page load by telling Next.js to perform SSR in the correct color scheme for the user:
 
 <pre class="language-tsx" data-title="_app.tsx"><code class="lang-tsx">const { withDsfr, dsfrDocumentApi } = createNextDsfrIntegrationApi({
   defaultColorScheme: 'system',

--- a/publishing-a-npm-modules-that-depends-on-react-dsfr.md
+++ b/publishing-a-npm-modules-that-depends-on-react-dsfr.md
@@ -16,5 +16,5 @@ The main takeway: &#x20;
 
 * [@codegouv/react-dsfr must be a peer dependency of your project](https://github.com/EIG6-Geocommuns/geocommuns-core/blob/55e015a453a681a12bfa84624ccfd243ce8a6150/package.json#L48). Any app that would use your library would need to explicitely install react-dsfr.  [For devloppement purpose, you want to add @codegouvfr/react-dsfr as devDependencies of your project](https://github.com/EIG6-Geocommuns/geocommuns-core/blob/55e015a453a681a12bfa84624ccfd243ce8a6150/package.json#L56). &#x20;
 * Do not add `"postinstall": "copy-dsfr-to-public"` in your library's package.json. It's the responsability of the host app to do so. &#x20;
-* If you rely on MUI, `@mui/material` `@emotion/styled` and `@emotion/react` should be peer dependencies as well.  You should add thoses modules as devDependencies.
+* If you rely on MUI, `@mui/material` `@emotion/styled` and `@emotion/react` should be peer dependencies as well.  You should add those modules as devDependencies.
 * If you use TSS: react-dsfr dosen't need to be a peerDependencies but @emotion/react does, you do not configure the emotion cache in your lib, that's the the responsability of the host app. &#x20;

--- a/routing.md
+++ b/routing.md
@@ -4,9 +4,9 @@ description: Like react-router or Next.js file system based route.
 
 # 🔀 Integration with routing libs
 
-Depending of the framework or routing library you are using, links between pages are not handled the same way.
+Depending on the framework or routing library you are using, links between pages are not handled the same way.
 
-Usually, you'll have a `<Link />` component provided by your routing library of choice. You need to let `react-dsfr` knows about it so that whenever a link is needed in a DSFR component, you can provide the correct props for you `<Link />` component.
+Usually, you'll have a `<Link />` component provided by your routing library of choice. You need to let `react-dsfr` know about it so that whenever a link is needed in a DSFR component, you can provide the correct props for your `<Link />` component.
 
 When registering your Link component, its props type will propagate to the react-dsfr API.
 
@@ -155,7 +155,7 @@ linkProps={{
 }}
 ```
 
-When react-dsfr detects that the `href` points to an external website it will use a regular `<a/>` Instead of the `<Link />` component. &#x20;
+When react-dsfr detects that the `href` points to an external website it will use a regular `<a/>` instead of the `<Link />` component. &#x20;
 
 #### Mailto links
 
@@ -234,7 +234,7 @@ linkProps={{
 }}
 ```
 
-When react-dsfr detects that the `href` points to an external website it will use a regular `<a/>` Instead of the `<Link />` component. &#x20;
+When react-dsfr detects that the `href` points to an external website it will use a regular `<a/>` instead of the `<Link />` component. &#x20;
 
 #### Mailto links
 
@@ -260,7 +260,7 @@ React-dsfr will automatically convert the underlying HTML element into a `<butto
 {% endtab %}
 
 {% tab title="type-route" %}
-[type-route](https://type-route.zilch.dev/) unlike most routing library doesn't export a `<Link />` component `<a />` are used directly.
+[type-route](https://type-route.zilch.dev/) unlike most routing library doesn't export a `<Link />` component, `<a />` are used directly.
 
 In consequence there isn't anything to setup.
 


### PR DESCRIPTION
- Fixed some typos
- Fixed broken link to Color helper
- Added a tip to restart local server to see newly added icons: when I started using react-dsfr, it took me some time to understand that, and it was asked a few weeks ago in the DSFR Slack, so it might be useful for other people :) 