### PR TITLE
feat(upload): add label props #167

### DIFF
--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -118,7 +118,7 @@ const { useTranslation, addUploadTranslations } = createComponentI18nApi({
     "componentName": symToStr({ Upload }),
     "frMessages": {
         /* spell-checker: disable */
-        "add_file": "Ajouter un fichier",
+        "add file": "Ajouter un fichier",
         "add_files": "Ajouter des fichiers",
         "hint": "Taille maximale : 500 Mo. Formats supportés : jpg, png, pdf. Plusieurs fichiers possibles."
         /* spell-checker: enable */

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -32,7 +32,7 @@ export const Upload = memo(
             disabled = false,
             hint = t("hint"),
             multiple = false,
-            label = multiple ? t("add_files") : t("add_file"),
+            label = multiple ? t("add files") : t("add file"),
             state = "default",
             stateRelatedMessage,
             nativeInputProps = {},

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -119,7 +119,7 @@ const { useTranslation, addUploadTranslations } = createComponentI18nApi({
     "frMessages": {
         /* spell-checker: disable */
         "add file": "Ajouter un fichier",
-        "add_files": "Ajouter des fichiers",
+        "add files": "Ajouter des fichiers",
         "hint": "Taille maximale : 500 Mo. Formats supportés : jpg, png, pdf. Plusieurs fichiers possibles."
         /* spell-checker: enable */
     }

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -129,7 +129,7 @@ addUploadTranslations({
     lang: "en",
     messages: {
         "add file": "Add file",
-        "add_files": "Add files",
+        "add files": "Add files",
         "hint": "Maximum size : 500 Mo. Supported formats : jpg, png, pdf. Many files possible."
     }
 });

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -128,7 +128,7 @@ const { useTranslation, addUploadTranslations } = createComponentI18nApi({
 addUploadTranslations({
     lang: "en",
     messages: {
-        "add_file": "Add file",
+        "add file": "Add file",
         "add_files": "Add files",
         "hint": "Maximum size : 500 Mo. Supported formats : jpg, png, pdf. Many files possible."
     }

--- a/src/Upload.tsx
+++ b/src/Upload.tsx
@@ -14,6 +14,7 @@ export type UploadProps = {
     hint?: string;
     /** @default false */
     multiple?: boolean;
+    label?: ReactNode;
     /** @default "default" */
     state?: "success" | "error" | "default";
     /** The message won't be displayed if state is "default" */
@@ -31,6 +32,7 @@ export const Upload = memo(
             disabled = false,
             hint = t("hint"),
             multiple = false,
+            label = multiple ? t("add_files") : t("add_file"),
             state = "default",
             stateRelatedMessage,
             nativeInputProps = {},
@@ -71,7 +73,7 @@ export const Upload = memo(
                 ref={ref}
             >
                 <label className={fr.cx("fr-label")} aria-disabled={disabled} htmlFor={inputId}>
-                    {t("add_files")}
+                    {label}
                     <span className={fr.cx("fr-hint-text")}>{hint}</span>
                 </label>
                 <input
@@ -116,6 +118,7 @@ const { useTranslation, addUploadTranslations } = createComponentI18nApi({
     "componentName": symToStr({ Upload }),
     "frMessages": {
         /* spell-checker: disable */
+        "add_file": "Ajouter un fichier",
         "add_files": "Ajouter des fichiers",
         "hint": "Taille maximale : 500 Mo. Formats supportés : jpg, png, pdf. Plusieurs fichiers possibles."
         /* spell-checker: enable */
@@ -125,6 +128,7 @@ const { useTranslation, addUploadTranslations } = createComponentI18nApi({
 addUploadTranslations({
     lang: "en",
     messages: {
+        "add_file": "Add file",
         "add_files": "Add files",
         "hint": "Maximum size : 500 Mo. Supported formats : jpg, png, pdf. Many files possible."
     }

--- a/stories/Upload.stories.tsx
+++ b/stories/Upload.stories.tsx
@@ -14,6 +14,10 @@ const { meta, getStory } = getStoryFactory({
         "disabled": {
             "control": { "type": "boolean" }
         },
+        "label": {
+            "description": "By default : Ajouter un fichier / des fichiers",
+            "control": { "type": "text" }
+        },
         "state": {
             "options": (() => {
                 const options = ["default", "success", "error"] as const;
@@ -44,6 +48,7 @@ const { meta, getStory } = getStoryFactory({
 export default meta;
 
 export const Default = getStory({
+    "label": undefined,
     "hint": "Texte de description",
     "state": "default",
     "stateRelatedMessage": "Text de validation / d'explication de l'erreur",
@@ -72,4 +77,8 @@ export const WithHint = getStory({
 
 export const Multiple = getStory({
     "multiple": true
+});
+
+export const WithCustomLabel = getStory({
+    "label": "Téléversez votre image de profil"
 });


### PR DESCRIPTION
- feat: Keep default label for backward compatibility
- doc: Update Upload story