### PR TITLE
fix: avoid duplicated ids from navbar & mobile modal

### DIFF
--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -144,7 +144,7 @@ export const Header = memo(
 
         const { Link } = getLink();
 
-        const quickAccessNode = (
+        const quickAccessNode = (fromModal: boolean) => (
             <ul className={fr.cx("fr-btns-group")}>
                 {quickAccessItems.map((quickAccessItem, i) => (
                     <li key={i}>
@@ -158,7 +158,7 @@ export const Header = memo(
                                 id={`${id}-quick-access-item-${generateValidHtmlId({
                                     "fallback": "",
                                     "text": quickAccessItem.text
-                                })}-${i}`}
+                                })}-${i}-${fromModal ? "modal" : "navbar"}`}
                                 quickAccessItem={quickAccessItem}
                             />
                         )}
@@ -312,7 +312,7 @@ export const Header = memo(
                                                     classes.toolsLinks
                                                 )}
                                             >
-                                                {quickAccessNode}
+                                                {quickAccessNode(false)}
                                             </div>
                                         )}
 
@@ -401,7 +401,7 @@ export const Header = memo(
                                         classes.menuLinks
                                     )}
                                 >
-                                    {quickAccessNode}
+                                    {quickAccessNode(true)}
                                 </div>
                                 {navigation !== undefined &&
                                     (navigation instanceof Array ? (


### PR DESCRIPTION
Hello,

I noticed that the quick access items in the navbar are duplicated in the HTML: once for the navbar and again for the mobile modal. This duplication results in repeated HTML ids, and my lighthouse CI is mad :grimacing: 

This pull request aims to resolve this problem.
