### PR TITLE
fix wrong type on target / currentTarget on SelectNext

### DIFF
--- a/src/SelectNext.tsx
+++ b/src/SelectNext.tsx
@@ -34,11 +34,24 @@ export type SelectProps<Options extends SelectProps.Option[]> = {
         value?: Options[number]["value"];
         onChange?: (
             e: Omit<ChangeEvent<HTMLSelectElement>, "target" | "currentTarget"> & {
-                target: Omit<ChangeEvent<HTMLSelectElement>, "value"> & {
+                target: Omit<EventTarget & HTMLSelectElement, "value" | "selectedOptions"> & {
                     value: Options[number]["value"];
+                    selectedOptions: HTMLCollectionOf<
+                        Omit<HTMLOptionElement, "value"> & {
+                            value: Options[number]["value"];
+                        }
+                    >;
                 };
-                currentTarget: Omit<ChangeEvent<HTMLSelectElement>, "value"> & {
+                currentTarget: Omit<
+                    EventTarget & HTMLSelectElement,
+                    "value" | "selectedOptions"
+                > & {
                     value: Options[number]["value"];
+                    selectedOptions: HTMLCollectionOf<
+                        Omit<HTMLOptionElement, "value"> & {
+                            value: Options[number]["value"];
+                        }
+                    >;
                 };
             }
         ) => void;

--- a/test/types/Select.tsx
+++ b/test/types/Select.tsx
@@ -262,3 +262,37 @@ import { assert, type Equals } from "tsafe";
         }}
     />;
 }
+
+{
+    const dogOrCatOptions = [
+        {
+            value: "dog",
+            label: "Dog"
+        },
+        {
+            value: "cat",
+            label: "Cat"
+        }
+    ] as const;
+
+    type DogOrCat = typeof dogOrCatOptions[number]["value"];
+    type SelectTarget = Omit<EventTarget & HTMLSelectElement, "value" | "selectedOptions"> & {
+        value: DogOrCat;
+        selectedOptions: HTMLCollectionOf<Omit<HTMLOptionElement, "value"> & { value: DogOrCat }>;
+    };
+    <Select
+        label="Dog or cat person?"
+        options={[...dogOrCatOptions]}
+        placeholder="Select an option"
+        nativeSelectProps={{
+            "onChange": event => {
+                assert<Equals<typeof event["currentTarget"], SelectTarget>>();
+                assert<Equals<typeof event["target"], SelectTarget>>();
+                const selectedValues = Array.from(event.target.selectedOptions).map(
+                    option => option.value
+                );
+                assert<Equals<typeof selectedValues, DogOrCat[]>>;
+            }
+        }}
+    />;
+}


### PR DESCRIPTION
Hi,

We've encountered a typing issue using SelectNext, turns out `target` and `currentTarget` on `onChange` event had the wrong type :

<img width="722" alt="Screenshot_2023-09-06_at_15 32 26" src="https://github.com/codegouvfr/react-dsfr/assets/2190121/3593d25e-46c1-422e-863a-6780c759c3ec">

I added type tests to check this. I think there's no consequences for the runtime. I also changed the selectedOptions prop, to fit our value typing needs.
