### PR TITLE
fix: remove duplicate icon when input type date

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -74,7 +74,7 @@ export const Input = memo(
             hintText,
             hideLabel,
             disabled = false,
-            iconId: iconId_props,
+            iconId,
             classes = {},
             style,
             state = "default",
@@ -160,10 +160,6 @@ export const Input = memo(
                             id={inputId}
                         />
                     );
-
-                    const iconId =
-                        iconId_props ??
-                        (nativeInputProps?.type === "date" ? "ri-calendar-line" : undefined);
 
                     return iconId === undefined ? (
                         nativeInputOrTextArea


### PR DESCRIPTION
When an Input is `type="date"`, DSFR already change the native icon with the ri-calendar icon in Webkit based browser.

In Firefox, since there is no `-moz-` support from DSFR, the native is displayed, therefore adding another one is wrong:
<img width="1031" alt="image" src="https://github.com/codegouvfr/react-dsfr/assets/5783789/c352c4ad-8cf4-4c66-81b1-093d51495a7f">

This PR remove the add of the date icon from the `<Input />` component