### PR TITLE
Add "value" for button props

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -72,6 +72,7 @@ export namespace ButtonProps {
         disabled?: boolean;
         /** Default "button" */
         type?: "button" | "submit" | "reset";
+        value?: string
     };
 }
 


### PR DESCRIPTION
For some use case we need to add "value" to button. We could use nativeButtonProps but it would be more natural to accept it as a base props in my opinion. The code already supports it but it's not typed

