### PR TITLE
feat(Badge): element can be a span (ref #200)

### DIFF
--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -14,6 +14,8 @@ export type BadgeProps = {
     severity?: AlertProps.Severity | "new";
     small?: boolean;
     noIcon?: boolean;
+    /** Default: "p" */
+    as?: "p" | "span";
     children: NonNullable<ReactNode>;
 };
 
@@ -23,6 +25,7 @@ export const Badge = memo(
         const {
             id: props_id,
             className,
+            as = "p",
             style,
             severity,
             small: isSmall = false,
@@ -38,10 +41,10 @@ export const Badge = memo(
             "explicitlyProvidedId": props_id
         });
 
-        return (
-            <p
-                id={id}
-                className={cx(
+        return React.createElement(
+            as,
+            {
+                className: cx(
                     fr.cx(
                         "fr-badge",
                         severity !== undefined && `fr-badge--${severity}`,
@@ -49,13 +52,13 @@ export const Badge = memo(
                         { "fr-badge--no-icon": noIcon || severity === undefined }
                     ),
                     className
-                )}
-                style={style}
-                ref={ref}
-                {...rest}
-            >
-                {children}
-            </p>
+                ),
+                id,
+                style,
+                ref,
+                ...rest
+            },
+            <>{children}</>
         );
     })
 );

--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -44,7 +44,7 @@ export const Badge = memo(
         return React.createElement(
             as,
             {
-                className: cx(
+                "className": cx(
                     fr.cx(
                         "fr-badge",
                         severity !== undefined && `fr-badge--${severity}`,

--- a/stories/Badge.stories.tsx
+++ b/stories/Badge.stories.tsx
@@ -29,6 +29,18 @@ const { meta, getStory } = getStoryFactory({
             "type": { "name": "boolean" },
             "description": "Set small badge size (`sm`) when true"
         },
+        "as": {
+            "options": (() => {
+                const options = ["p", "span", undefined] as const;
+
+                assert<Equals<typeof options[number], BadgeProps["as"]>>();
+
+                return options;
+            })(),
+            "control": { type: "select", labels: { null: "default p element" } },
+            "description":
+                "You can specify a 'span' element instead of default 'p' if the badge is inside a `<p>`."
+        },
         "children": {
             "type": { "name": "string", "required": true },
             "description": "Label to display on the badge"

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Header } from "../dist/Header";
+import { Badge } from "../dist/Badge";
 import { MainNavigation } from "../dist/MainNavigation";
 import { sectionName } from "./sectionName";
 import { getStoryFactory } from "./getStory";
@@ -113,6 +114,29 @@ export const SimpleHeaderWithServiceTitleAndTagline = getStory({
     },
     "serviceTitle": "Nom du site / service",
     "serviceTagline": "baseline - précisions sur l'organisation"
+});
+
+export const SimpleHeaderWithServiceTitleAndBetaBadge = getStory({
+    "id": "fr-header-simple-header-with-service-title-and-tagline",
+    "brandTop": (
+        <>
+            INTITULE
+            <br />
+            OFFICIEL
+        </>
+    ),
+    "homeLinkProps": {
+        "href": "/",
+        "title": "Accueil - Nom de l’entité (ministère, secrétariat d‘état, gouvernement)"
+    },
+    "serviceTitle": (
+        <>
+            Nom du site / service{" "}
+            <Badge noIcon severity="success" as="span">
+                Beta
+            </Badge>
+        </>
+    )
 });
 
 export const HeaderWithQuickAccessItems = getStory(


### PR DESCRIPTION
- Badge can be a span or a p (default p). Same logic as the Summary component.
- Update Badge default story
- Create Header story with beta badge

Note: it works locally on storybook, but I'm not sure how to test on vite or next app for example. I launched the command `yarn start-vite` but it didn't create a local dev server, so I don't know what I'm supposed to do.