### PR TITLE
fix:add-aria-hidden-to-display-svg

### DIFF
--- a/src/Display/Display.tsx
+++ b/src/Display/Display.tsx
@@ -76,6 +76,7 @@ export function Display() {
                                     </label>
                                     <div className={fr.cx("fr-radio-rich__img")}>
                                         <svg
+                                            aria-hidden="true"
                                             xmlns="http://www.w3.org/2000/svg"
                                             //className={fr.cx("fr-artwork")}
                                             width="80px"


### PR DESCRIPTION
As described in the doc and for accessibility purposes, the aria-hidden=true attribute was missing on the svgs in the display component

https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/parametre-d-affichage/