### PR TITLE
Open partners logo link in new tabs

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -366,8 +366,12 @@ export const Footer = memo(
                                     {mainPartnersLogo !== undefined && (
                                         <a
                                             href={mainPartnersLogo.href}
+                                            target="_blank"
+                                            title={`${mainPartnersLogo.href} - ${t(
+                                                "open new window"
+                                            )}`}
                                             className={cx(
-                                                fr.cx("fr-footer__partners-link"),
+                                                fr.cx("fr-footer__partners-link", "fr-raw-link"),
                                                 classes.partnersLink
                                             )}
                                         >
@@ -395,8 +399,15 @@ export const Footer = memo(
                                                 <li key={i}>
                                                     <a
                                                         href={logo.href}
+                                                        target="_blank"
+                                                        title={`${logo.href} - ${t(
+                                                            "open new window"
+                                                        )}`}
                                                         className={cx(
-                                                            fr.cx("fr-footer__partners-link"),
+                                                            fr.cx(
+                                                                "fr-footer__partners-link",
+                                                                "fr-raw-link"
+                                                            ),
                                                             classes.partnersLink
                                                         )}
                                                     >


### PR DESCRIPTION
Always open partners logo links in new tabs.

See issue #205 .
Among the possible fixes, this is the most simple and this doesn't introduce any breaking change.
Making opening in new tabs the default and only behavior makes sense. Other external links in the Footer (legifrance.gouv.fr, gouvernement.fr...)  have the same behavior.