### PR TITLE
fix(footer): add missing classes.operatorLogo

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -271,7 +271,7 @@ export const Footer = memo(
                         >
                             {(() => {
                                 const children = (
-                                    <p className={fr.cx("fr-logo", classes.logo)}>{brandTop}</p>
+                                    <p className={cx(fr.cx("fr-logo"), classes.logo)}>{brandTop}</p>
                                 );
 
                                 return operatorLogo !== undefined ? (

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -61,6 +61,7 @@ export type FooterProps = {
             | "bottomCopy"
             | "brandLink"
             | "logo"
+            | "operatorLogo"
             | "partners"
             | "partnersTitle"
             | "partnersLogos"
@@ -269,7 +270,9 @@ export const Footer = memo(
                             )}
                         >
                             {(() => {
-                                const children = <p className={fr.cx("fr-logo")}>{brandTop}</p>;
+                                const children = (
+                                    <p className={fr.cx("fr-logo", classes.logo)}>{brandTop}</p>
+                                );
 
                                 return operatorLogo !== undefined ? (
                                     children
@@ -287,7 +290,10 @@ export const Footer = memo(
                                     )}
                                 >
                                     <img
-                                        className={cx(fr.cx("fr-footer__logo"), classes.logo)}
+                                        className={cx(
+                                            fr.cx("fr-footer__logo"),
+                                            classes.operatorLogo
+                                        )}
                                         style={(() => {
                                             switch (operatorLogo.orientation) {
                                                 case "vertical":


### PR DESCRIPTION
add a `classes.operatorLogo` for the footer and use `classes.logo` for the main logo.

the goal is to be able to apply a custom class to the main logo

This will be a breaking change for those using `classes.logo` for the `operatorLogo`

Not sure if this was intended or not