### PR TITLE
feat: header operator link

### DIFF
--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -42,8 +42,12 @@ export type HeaderProps = {
          * If "horizontal": 16x9
          */
         imgUrl: string;
-        /** Textual alternative of the image, it MUST include the text present in the image*/
+        /** Textual alternative of the image, it MUST include the text present in the image */
         alt: string;
+        /**
+         * Custom link props, if not provided, the operator logo will be wrapped in a link that points to the home page
+         */
+        linkProps?: RegisteredLinkProps & { title: string };
     };
     renderSearchInput?: (
         /**
@@ -168,6 +172,8 @@ export const Header = memo(
             </ul>
         );
 
+        const hasOperatorLink = operatorLogo?.linkProps !== undefined;
+
         return (
             <>
                 <Display />
@@ -184,7 +190,10 @@ export const Header = memo(
                             <div className={cx(fr.cx("fr-header__body-row"), classes.bodyRow)}>
                                 <div
                                     className={cx(
-                                        fr.cx("fr-header__brand", "fr-enlarge-link"),
+                                        fr.cx(
+                                            "fr-header__brand",
+                                            !hasOperatorLink && "fr-enlarge-link"
+                                        ),
                                         classes.brand
                                     )}
                                 >
@@ -210,30 +219,45 @@ export const Header = memo(
                                         {operatorLogo !== undefined && (
                                             <div
                                                 className={cx(
-                                                    fr.cx("fr-header__operator"),
+                                                    fr.cx(
+                                                        "fr-header__operator",
+                                                        hasOperatorLink && "fr-enlarge-link"
+                                                    ),
                                                     classes.operator
                                                 )}
                                             >
-                                                <Link {...homeLinkProps}>
-                                                    <img
-                                                        className={cx(
-                                                            fr.cx("fr-responsive-img"),
-                                                            classes.operator
-                                                        )}
-                                                        style={(() => {
-                                                            switch (operatorLogo.orientation) {
-                                                                case "vertical":
-                                                                    return { "width": "3.5rem" };
-                                                                case "horizontal":
-                                                                    return {
-                                                                        "maxWidth": "9.0625rem"
-                                                                    };
-                                                            }
-                                                        })()}
-                                                        src={operatorLogo.imgUrl}
-                                                        alt={operatorLogo.alt}
-                                                    />
-                                                </Link>
+                                                {(() => {
+                                                    const children = (
+                                                        <img
+                                                            className={cx(
+                                                                fr.cx("fr-responsive-img"),
+                                                                classes.operator
+                                                            )}
+                                                            style={(() => {
+                                                                switch (operatorLogo.orientation) {
+                                                                    case "vertical":
+                                                                        return {
+                                                                            "width": "3.5rem"
+                                                                        };
+                                                                    case "horizontal":
+                                                                        return {
+                                                                            "maxWidth": "9.0625rem"
+                                                                        };
+                                                                }
+                                                            })()}
+                                                            src={operatorLogo.imgUrl}
+                                                            alt={operatorLogo.alt}
+                                                        />
+                                                    );
+
+                                                    return hasOperatorLink ? (
+                                                        <Link {...operatorLogo.linkProps}>
+                                                            {children}
+                                                        </Link>
+                                                    ) : (
+                                                        children
+                                                    );
+                                                })()}
                                             </div>
                                         )}
 
@@ -276,7 +300,10 @@ export const Header = memo(
                                     {serviceTitle !== undefined && (
                                         <div
                                             className={cx(
-                                                fr.cx("fr-header__service"),
+                                                fr.cx(
+                                                    "fr-header__service",
+                                                    hasOperatorLink && "fr-enlarge-link"
+                                                ),
                                                 classes.service
                                             )}
                                         >

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -500,110 +500,124 @@ export const HeaderWithQuickAccessItemsNavItemsAndSearchEngine = getStory(
     }
 );
 
-export const HeaderWithVerticalOperatorLogo = getStory(
-    {
-        "id": "fr-header-header-with-vertical-operator-logo",
-        "brandTop": (
-            <>
-                INTITULE
-                <br />
-                OFFICIEL
-            </>
-        ),
-        "homeLinkProps": {
-            "href": "/",
+export const HeaderWithVerticalOperatorLogo = getStory({
+    "id": "fr-header-header-with-vertical-operator-logo",
+    "brandTop": (
+        <>
+            INTITULE
+            <br />
+            OFFICIEL
+        </>
+    ),
+    "homeLinkProps": {
+        "href": "/",
+        "title":
+            "Accueil - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française"
+    },
+    "onSearchButtonClick": text => alert(`TODO: implement search with text: ${text}`),
+    "operatorLogo": {
+        "orientation": "vertical",
+        "imgUrl": placeholder_9x16ImgUrl,
+        "alt": "[À MODIFIER - texte alternatif de l’image]"
+    }
+});
+
+export const WithHorizontalOperatorLogo = getStory({
+    "id": "fr-header-with-horizontal-operator-logo",
+    "brandTop": (
+        <>
+            INTITULE
+            <br />
+            OFFICIEL
+        </>
+    ),
+    "homeLinkProps": {
+        "href": "/",
+        "title": "Accueil - Nom de l’entité (ministère, secrétariat d‘état, gouvernement)"
+    },
+    "serviceTitle": "Nom du site / service",
+    "serviceTagline": "baseline - précisions sur l'organisation",
+    "quickAccessItems": [
+        {
+            "iconId": "fr-icon-add-circle-line",
+            "text": "Créer un espace",
+            "linkProps": {
+                "href": "#"
+            }
+        },
+        {
+            "iconId": "fr-icon-lock-line",
+            "text": "Se connecter",
+            "linkProps": {
+                "href": "#"
+            }
+        },
+        {
+            "iconId": "fr-icon-account-line",
+            "text": "S’enregistrer",
+            "linkProps": {
+                "href": "#"
+            }
+        }
+    ],
+    "onSearchButtonClick": text => alert(`TODO: implement search with text: ${text}`),
+    "operatorLogo": {
+        "orientation": "horizontal",
+        "imgUrl": placeholder_16x9ImgUrl,
+        "alt": "[À MODIFIER - texte alternatif de l’image]"
+    }
+});
+
+export const WithOperatorLogoWithLink = getStory({
+    "id": "fr-header-with-operator-logo-with-link",
+    "brandTop": (
+        <>
+            INTITULE
+            <br />
+            OFFICIEL
+        </>
+    ),
+    "homeLinkProps": {
+        "href": "/",
+        "title": "Accueil - Nom de l’entité (ministère, secrétariat d‘état, gouvernement)"
+    },
+    "serviceTitle": "Nom du site / service",
+    "serviceTagline": "baseline - précisions sur l'organisation",
+    "quickAccessItems": [
+        {
+            "iconId": "fr-icon-add-circle-line",
+            "text": "Créer un espace",
+            "linkProps": {
+                "href": "#"
+            }
+        },
+        {
+            "iconId": "fr-icon-lock-line",
+            "text": "Se connecter",
+            "linkProps": {
+                "href": "#"
+            }
+        },
+        {
+            "iconId": "fr-icon-account-line",
+            "text": "S’enregistrer",
+            "linkProps": {
+                "href": "#"
+            }
+        }
+    ],
+    "onSearchButtonClick": text => alert(`TODO: implement search with text: ${text}`),
+    "operatorLogo": {
+        "orientation": "horizontal",
+        "imgUrl": placeholder_16x9ImgUrl,
+        "alt": "[À MODIFIER - texte alternatif de l’image]",
+        "linkProps": {
+            "href": "#",
             "title":
                 "Accueil - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française"
-        },
-        "onSearchButtonClick": text => alert(`TODO: implement search with text: ${text}`),
-        "operatorLogo": {
-            "orientation": "vertical",
-            "imgUrl": placeholder_9x16ImgUrl,
-            "alt": "[À MODIFIER - texte alternatif de l’image]"
         }
-    },
-
-    {
-        "description": `
-
-\`\`\`tsx
-
-<Header
-    //...
-    renderSearchInput={({ className, id, placeholder, type }) => 
-        <input className={className} id={id} placeholder={placeholder} type={type} />
     }
-/>
-        
-\`\`\`
-    
-    `
-    }
-);
-
-export const WithHorizontalOperatorLogo = getStory(
-    {
-        "id": "fr-header-with-horizontal-operator-logo",
-        "brandTop": (
-            <>
-                INTITULE
-                <br />
-                OFFICIEL
-            </>
-        ),
-        "homeLinkProps": {
-            "href": "/",
-            "title": "Accueil - Nom de l’entité (ministère, secrétariat d‘état, gouvernement)"
-        },
-        "serviceTitle": "Nom du site / service",
-        "serviceTagline": "baseline - précisions sur l'organisation",
-        "quickAccessItems": [
-            {
-                "iconId": "fr-icon-add-circle-line",
-                "text": "Créer un espace",
-                "linkProps": {
-                    "href": "#"
-                }
-            },
-            {
-                "iconId": "fr-icon-lock-line",
-                "text": "Se connecter",
-                "linkProps": {
-                    "href": "#"
-                }
-            },
-            {
-                "iconId": "fr-icon-account-line",
-                "text": "S’enregistrer",
-                "linkProps": {
-                    "href": "#"
-                }
-            }
-        ],
-        "onSearchButtonClick": text => alert(`TODO: implement search with text: ${text}`),
-        "operatorLogo": {
-            "orientation": "horizontal",
-            "imgUrl": placeholder_16x9ImgUrl,
-            "alt": "[À MODIFIER - texte alternatif de l’image]"
-        }
-    },
-    {
-        "description": `
-
-\`\`\`tsx
-
-<Header
-    //...
-    renderSearchInput={({ className, id, name, placeholder, type }) => 
-        <input className={className} id={id} name={name} placeholder={placeholder} type={type} />
-    }
-/>
-        
-\`\`\`
-    
-    `
-    }
-);
+});
 
 export const NavigationAsCustomNode = getStory(
     {


### PR DESCRIPTION
Add a way to "split" the enlarge link when an operator logo is given with additional link props