### PR TITLE
mui: override autocomplete style

### DIFF
--- a/src/mui.tsx
+++ b/src/mui.tsx
@@ -205,12 +205,18 @@ export function getMuiDsfrThemeOptions(params: {
             },
             "MuiAutocomplete": {
                 "styleOverrides": {
+                    "listbox": {
+                        "padding": 0
+                    },
                     "option": {
-                        "border": "1px solid transparent",
+                        "padding": `${fr.spacing("2w")} !important`,
+                        "&.Mui-focused": {
+                            "backgroundColor":
+                                decisions.background.open.blueFrance.default + " !important"
+                        },
                         "&.Mui-focusVisible": {
                             "backgroundColor":
-                                decisions.background.contrast.grey.default + " !important",
-                            "border": `1px solid ${decisions.border.active.blueFrance.default}`
+                                decisions.background.open.blueFrance.default + " !important"
                         }
                     }
                 }
@@ -331,6 +337,7 @@ export function createMuiDsfrTheme(
     params: { isDark: boolean; breakpointsValues: BreakpointsValues },
     ...args: object[]
 ): MuiTheme {
+    console.log("test");
     const muiTheme = createTheme(getMuiDsfrThemeOptions(params), ...args);
 
     return muiTheme;


### PR DESCRIPTION
Change the global style for mui autocomplete 
With this code 

```tsx
<MuiDsfrThemeProvider>
            <Autocomplete
                disablePortal
                id="combo-box-demo"
                options={communes}
                sx={{ width: 300 }}
                renderInput={params => <TextField {...params} label="Commencez votre saisie" />}
            />

            <Autocomplete
                disablePortal
                id="combo-box-demo"
                options={communes}
                sx={{ width: 300 }}
                renderInput={({ InputProps, disabled, id, inputProps }) => (
                    <Input
                        ref={InputProps.ref}
                        label="Le label du champ"
                        id={id}
                        disabled={disabled}
                        nativeInputProps={{ ...inputProps, placeholder: "Commencez votre saisie" }}
                    />
                )}
            />
        </MuiDsfrThemeProvider>
```

Before : 
<img width="332" alt="Capture d’écran 2024-03-05 à 17 11 16" src="https://github.com/codegouvfr/react-dsfr/assets/81740200/fd292604-9d06-42dc-a63d-f481cd9a1f0b">
<img width="392" alt="Capture d’écran 2024-03-05 à 17 11 29" src="https://github.com/codegouvfr/react-dsfr/assets/81740200/c0001fb0-09bb-4530-b27a-35f0cdbe920e">


After : 
<img width="543" alt="Capture d’écran 2024-03-05 à 17 03 09" src="https://github.com/codegouvfr/react-dsfr/assets/81740200/076d2aeb-8c1f-4474-ae6f-51e33fd44e2d">
<img width="436" alt="Capture d’écran 2024-03-05 à 17 03 29" src="https://github.com/codegouvfr/react-dsfr/assets/81740200/03c0745d-39f3-4cb8-9d2e-eedf812bcfa3">
