### PR TITLE
feat(Link): add LinkProps option

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -14,12 +14,16 @@ type HTMLAnchorProps = DetailedHTMLProps<
 export interface RegisterLink {}
 
 export type RegisteredLinkProps = RegisterLink extends { Link: infer Link }
-    ?
-          | Omit<UnpackProps<Link>, "children">
-          | (Omit<HTMLAnchorProps, "children" | "href"> & {
-                href: string;
-            })
+    ? LinkPropsWithoutChildren<UnpackProps<Link>>
+    : RegisterLink extends { LinkProps: infer LinkProps }
+    ? LinkPropsWithoutChildren<LinkProps>
     : Omit<HTMLAnchorProps, "children">;
+
+type LinkPropsWithoutChildren<LinkProps> =
+    | Omit<LinkProps, "children">
+    | (Omit<HTMLAnchorProps, "children" | "href"> & {
+          href: string;
+      });
 
 let Link: React.ComponentType<RegisteredLinkProps & { children: ReactNode }> = props => {
     const { href, ...rest } = props as { to?: string; href?: string };


### PR DESCRIPTION
Avec Tanstack Router v1.22.2, l'inférence du type des props de `Link` renvoie { to: any } 
![image](https://github.com/codegouvfr/react-dsfr/assets/32564108/500d0e1f-227d-4c21-be0c-7f69384943f9)

Cette PR ajoute la possibilité de spécifier `LinkProps` lors de l'override de l'interface `RegisterLink`
```ts
import type { LinkProps } from "@tanstack/react-router";

declare module "@codegouvfr/react-dsfr/link" {
  interface RegisterLink {
    // Link: typeof Link;
    LinkProps: LinkProps;
  }
}
```

![image](https://github.com/codegouvfr/react-dsfr/assets/32564108/c01b22f0-1a29-4ca9-aada-3c5318bed5f5)

Aussi, `@tanstack/react-router` n'exporte plus le type LinkComponent, il faut utiliser `typeof Link` donc la doc est obsolète ici: https://react-dsfr.codegouv.studio/routing

