### PR TITLE
Add space in wording

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -483,7 +483,7 @@ export const Footer = memo(
                                           })
                                       ]),
                                 id<FooterProps.BottomItem>({
-                                    "text": `${t("accessibility")}: ${t(accessibility)}`,
+                                    "text": `${t("accessibility")} : ${t(accessibility)}`,
                                     "linkProps": accessibilityLinkProps ?? ({} as any)
                                 }),
                                 ...(termsLinkProps === undefined


### PR DESCRIPTION
En France, on met un espace avant et après les ":"