### PR TITLE
Add id attribute on Accordion toggler

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -92,6 +92,7 @@ export const Accordion = memo(
                         aria-controls={collapseElementId}
                         onClick={onExtendButtonClick}
                         type="button"
+                        id={`${id}__toggle-btn`}
                     >
                         {label}
                     </button>


### PR DESCRIPTION
For end-to-end tests or tracking, we find it useful to use IDs on interactive elements. I just added an ID on the toggle `button` to generate it from Accordion's id.