### PR TITLE
fix(Pagination): Allow usage of Pagination component with Next.js

### DIFF
--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, type CSSProperties } from "react";
+import React, { memo, forwardRef, type CSSProperties, ReactNode } from "react";
 import { symToStr } from "tsafe/symToStr";
 import { assert } from "tsafe/assert";
 import type { Equals } from "tsafe";
@@ -7,6 +7,18 @@ import { cx } from "./tools/cx";
 import { createComponentI18nApi } from "./i18n";
 import { RegisteredLinkProps, getLink } from "./link";
 import { useAnalyticsId } from "./tools/useAnalyticsId";
+
+const DynamicLink = ({
+    useReactLinkComponent,
+    children,
+    ...rest
+}: {
+    useReactLinkComponent: boolean;
+    children: ReactNode;
+}) => {
+    const { Link } = getLink();
+    return useReactLinkComponent ? <Link {...rest}>{children}</Link> : <a {...rest}>{children}</a>;
+};
 
 export type PaginationProps = {
     id?: string;
@@ -100,36 +112,43 @@ export const Pagination = memo(
                 <ul className={cx(fr.cx("fr-pagination__list"), classes.list)}>
                     {showFirstLast && (
                         <li>
-                            <Link
+                            <DynamicLink
+                                useReactLinkComponent={defaultPage > 1}
                                 {...(count > 0 && defaultPage > 1 && getPageLinkProps(1))}
-                                className={cx(
-                                    fr.cx("fr-pagination__link", "fr-pagination__link--first"),
-                                    classes.link,
-                                    getPageLinkProps(1).className
-                                )}
-                                aria-disabled={count > 0 && defaultPage > 1 ? true : undefined}
-                                role="link"
+                                {...{
+                                    className: cx(
+                                        fr.cx("fr-pagination__link", "fr-pagination__link--first"),
+                                        classes.link,
+                                        getPageLinkProps(1).className
+                                    ),
+                                    "aria-disabled":
+                                        count > 0 && defaultPage > 1 ? true : undefined,
+                                    role: "link"
+                                }}
                             >
                                 {t("first page")}
-                            </Link>
+                            </DynamicLink>
                         </li>
                     )}
                     <li>
-                        <Link
-                            className={cx(
-                                fr.cx(
-                                    "fr-pagination__link",
-                                    "fr-pagination__link--prev",
-                                    "fr-pagination__link--lg-label"
-                                ),
-                                classes.link
-                            )}
+                        <DynamicLink
+                            useReactLinkComponent={defaultPage > 1}
                             {...(defaultPage > 1 && getPageLinkProps(defaultPage - 1))}
-                            aria-disabled={defaultPage <= 1 ? true : undefined}
-                            role="link"
+                            {...{
+                                className: cx(
+                                    fr.cx(
+                                        "fr-pagination__link",
+                                        "fr-pagination__link--prev",
+                                        "fr-pagination__link--lg-label"
+                                    ),
+                                    classes.link
+                                ),
+                                "aria-disabled": defaultPage <= 1 ? true : undefined,
+                                role: "link"
+                            }}
                         >
-                            {t("previous page")}
-                        </Link>
+                            {t("first page")}
+                        </DynamicLink>
                     </li>
                     {parts.map(part => (
                         <li key={part.number}>
@@ -150,34 +169,40 @@ export const Pagination = memo(
                         </li>
                     ))}
                     <li>
-                        <Link
-                            className={cx(
-                                fr.cx(
-                                    "fr-pagination__link",
-                                    "fr-pagination__link--next",
-                                    "fr-pagination__link--lg-label"
-                                ),
-                                classes.link
-                            )}
+                        <DynamicLink
+                            useReactLinkComponent={defaultPage < count}
                             {...(defaultPage < count && getPageLinkProps(defaultPage + 1))}
-                            aria-disabled={defaultPage < count ? true : undefined}
-                            role="link"
+                            {...{
+                                className: cx(
+                                    fr.cx(
+                                        "fr-pagination__link",
+                                        "fr-pagination__link--next",
+                                        "fr-pagination__link--lg-label"
+                                    ),
+                                    classes.link
+                                ),
+                                "aria-disabled": defaultPage < count ? true : undefined,
+                                role: "link"
+                            }}
                         >
                             {t("next page")}
-                        </Link>
+                        </DynamicLink>
                     </li>
                     {showFirstLast && (
                         <li>
-                            <Link
-                                className={cx(
-                                    fr.cx("fr-pagination__link", "fr-pagination__link--last"),
-                                    classes.link
-                                )}
+                            <DynamicLink
+                                useReactLinkComponent={defaultPage < count}
                                 {...(defaultPage < count && getPageLinkProps(count))}
-                                aria-disabled={defaultPage < count ? true : undefined}
+                                {...{
+                                    className: cx(
+                                        fr.cx("fr-pagination__link", "fr-pagination__link--last"),
+                                        classes.link
+                                    ),
+                                    "aria-disabled": defaultPage < count ? true : undefined
+                                }}
                             >
                                 {t("last page")}
-                            </Link>
+                            </DynamicLink>
                         </li>
                     )}
                 </ul>

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -147,7 +147,7 @@ export const Pagination = memo(
                                 role: "link"
                             }}
                         >
-                            {t("first page")}
+                            {t("previous page")}
                         </DynamicLink>
                     </li>
                     {parts.map(part => (


### PR DESCRIPTION
ATM when on the first or last page of the pagination component, a `Link` component is generated with no `href` attribute for the `first / last page` and `previous / next page` elements of the pagination.

The issue seem to have been running for almost a year now https://github.com/codegouvfr/react-dsfr/issues/170

Issue : Since NextJS can't handle `Link` without an `href` attribute, the whole page crashes if we're on the first or last page of the pagination component.

Steps to reproduce : Clone react-dsfr, use a Pagination component in `test/integration/next-appdir/ui/ClientComponent.tsx`.

Set `defaultPage` attribue to either 1 or the same as `count` count attribute, and `count` > 1.
Run and try to access the page.

example : 

 ```
 <Pagination
        getPageLinkProps={(page) => ({ href: `?page=${page}` })}
        count={10}
        defaultPage={1}>
</Pagination>
  ```

Solution :
I tried to solve this in the most simple and straight forward way :
If we're on either the first or last page of the Pagination component, then we use a `<a>` HTML element instead of `<Link>` for those specific action links.

Since the link **is not clickable anyway** in such case, this should not cause any issue or regression. 