### PR TITLE
Ajoute nativeImgProps pour les Card

### DIFF
--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -238,7 +238,11 @@ export const Card = memo(
                                 src={imageUrl}
                                 alt={imageAlt}
                                 {...nativeImgProps}
-                                 className={cx(fr.cx("fr-responsive-img"), classes.imgTag, nativeImgProps?.className)}
+                                className={cx(
+                                    fr.cx("fr-responsive-img"),
+                                    classes.imgTag,
+                                    nativeImgProps?.className
+                                )}
                             />
                         </div>
                         {badge !== undefined && (

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -235,10 +235,10 @@ export const Card = memo(
                     <div className={cx(fr.cx("fr-card__header"), classes.header)}>
                         <div className={cx(fr.cx("fr-card__img"), classes.img)}>
                             <img
-                                className={cx(fr.cx("fr-responsive-img"), classes.imgTag)}
                                 src={imageUrl}
                                 alt={imageAlt}
                                 {...nativeImgProps}
+                                 className={cx(fr.cx("fr-responsive-img"), classes.imgTag, nativeImgProps?.className)}
                             />
                         </div>
                         {badge !== undefined && (

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -1,4 +1,11 @@
-import React, { memo, forwardRef, type ReactNode, type CSSProperties } from "react";
+import React, {
+    memo,
+    forwardRef,
+    type ReactNode,
+    type CSSProperties,
+    DetailedHTMLProps,
+    ImgHTMLAttributes
+} from "react";
 import { symToStr } from "tsafe/symToStr";
 import { assert } from "tsafe/assert";
 import type { Equals } from "tsafe";
@@ -88,6 +95,7 @@ export namespace CardProps {
         imageUrl: string;
         imageAlt: string;
         imageComponent?: never;
+        nativeImgProps?: DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
     };
 
     export type WithImageComponent = {
@@ -95,6 +103,7 @@ export namespace CardProps {
         imageUrl?: never;
         imageAlt?: never;
         imageComponent: ReactNode;
+        nativeImgProps?: never;
     };
 
     export type WithoutImage = {
@@ -102,6 +111,7 @@ export namespace CardProps {
         imageUrl?: never;
         imageAlt?: never;
         imageComponent?: never;
+        nativeImgProps?: never;
     };
 }
 
@@ -118,6 +128,7 @@ export const Card = memo(
             imageUrl,
             imageAlt,
             imageComponent,
+            nativeImgProps,
             start,
             detail,
             end,
@@ -227,6 +238,7 @@ export const Card = memo(
                                 className={cx(fr.cx("fr-responsive-img"), classes.imgTag)}
                                 src={imageUrl}
                                 alt={imageAlt}
+                                {...nativeImgProps}
                             />
                         </div>
                         {badge !== undefined && (


### PR DESCRIPTION
J'ai dû recréer une PR pour voir un historique OK suite à la PR https://github.com/codegouvfr/react-dsfr/pull/285.

Comme conseillé dans la PR, j'introduis `nativeImgProps` qui est transmis à l'image des Card. (et donc le fameux `loading="lazy"` qui m'intéresse)