### PR TITLE
fix(header): define an aria-label on the input search button for accessibility

### DIFF
--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -298,6 +298,7 @@ export const Header = memo(
                                                         data-fr-opened={false}
                                                         aria-controls={searchModalId}
                                                         title={tSearchBar("label")}
+                                                        aria-label={tSearchBar("label")}
                                                     >
                                                         {tSearchBar("label")}
                                                     </button>


### PR DESCRIPTION
Cette PR corrige les warnings provenant de DSFR au sujet de l'accessibilité :

![image](https://github.com/user-attachments/assets/84d3b8c7-214d-4dab-9b8f-dd22f915766c)

En se référent au code du DSFR, on voit que le soucis provient du champ `aria-labelledby` ou `aria-label` manquant sur le bouton de la recherche : https://github.com/GouvernementFR/dsfr/blob/fe9d66b4ccaa7c3a3c0cb07eca69ddd6787965c4/src/component/modal/script/modal/modal.js#L120

Comme on n'a pas de composant à référencer pour le `aria-labelledby`, on va utiliser le `aria-label` où l'on va mettre le même texte que dans `title`. (cf: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)