### PR TITLE
[Accessibility] Input/Select - wrapped error message within live region

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -183,11 +183,7 @@ export const Input = memo(
                         nativeInputOrTextArea
                     );
                 })()}
-                <div
-                    id={messagesGroupId}
-                    className={fr.cx("fr-messages-group")}
-                    aria-live="assertive"
-                >
+                <div id={messagesGroupId} className={fr.cx("fr-messages-group")} aria-live="polite">
                     {state !== "default" && (
                         <p
                             id={messageId}

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -101,6 +101,7 @@ export const Input = memo(
         })();
 
         const messageId = `${inputId}-desc-error`;
+        const messagesGroupId = `${inputId}-messages-group`;
 
         return (
             <div
@@ -182,29 +183,35 @@ export const Input = memo(
                         nativeInputOrTextArea
                     );
                 })()}
-                {state !== "default" && (
-                    <p
-                        id={messageId}
-                        className={cx(
-                            fr.cx(
-                                (() => {
-                                    switch (state) {
-                                        case "error":
-                                            return "fr-error-text";
-                                        case "success":
-                                            return "fr-valid-text";
-                                        case "info":
-                                            return "fr-info-text";
-                                    }
-                                    assert<Equals<typeof state, never>>();
-                                })()
-                            ),
-                            classes.message
-                        )}
-                    >
-                        {stateRelatedMessage}
-                    </p>
-                )}
+                <div
+                    id={messagesGroupId}
+                    className={fr.cx("fr-messages-group")}
+                    aria-live="assertive"
+                >
+                    {state !== "default" && (
+                        <p
+                            id={messageId}
+                            className={cx(
+                                fr.cx(
+                                    (() => {
+                                        switch (state) {
+                                            case "error":
+                                                return "fr-error-text";
+                                            case "success":
+                                                return "fr-valid-text";
+                                            case "info":
+                                                return "fr-info-text";
+                                        }
+                                        assert<Equals<typeof state, never>>();
+                                    })()
+                                ),
+                                classes.message
+                            )}
+                        >
+                            {stateRelatedMessage}
+                        </p>
+                    )}
+                </div>
             </div>
         );
     })

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -64,6 +64,7 @@ export const Select = memo(
         })();
 
         const stateDescriptionId = `select-${useId()}-desc`;
+        const messagesGroupId = `${selectId}-messages-group`;
 
         return (
             <div
@@ -107,24 +108,26 @@ export const Select = memo(
                 >
                     {children}
                 </select>
-                {state !== "default" && (
-                    <p
-                        id={stateDescriptionId}
-                        className={fr.cx(
-                            (() => {
-                                switch (state) {
-                                    case "error":
-                                        return "fr-error-text";
-                                    case "success":
-                                        return "fr-valid-text";
-                                }
-                                assert<Equals<typeof state, never>>(false);
-                            })()
-                        )}
-                    >
-                        {stateRelatedMessage}
-                    </p>
-                )}
+                <div id={messagesGroupId} className={fr.cx("fr-messages-group")} aria-live="polite">
+                    {state !== "default" && (
+                        <p
+                            id={stateDescriptionId}
+                            className={fr.cx(
+                                (() => {
+                                    switch (state) {
+                                        case "error":
+                                            return "fr-error-text";
+                                        case "success":
+                                            return "fr-valid-text";
+                                    }
+                                    assert<Equals<typeof state, never>>(false);
+                                })()
+                            )}
+                        >
+                            {stateRelatedMessage}
+                        </p>
+                    )}
+                </div>
             </div>
         );
     })


### PR DESCRIPTION
### Description
Wrapped the error message within a parent with attribute ~~aria-live="assertive"~~ aria-live="polite" so that it gets announced by the screen reader

Update 1: Added similar wrapper to Select component

### Github issue
- https://github.com/codegouvfr/react-dsfr/issues/311