### PR TITLE
[Accessibility] Modal component - aria-hidden missing from the span representing an icon

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -97,7 +97,10 @@ const Modal = memo(
                                 <div className={fr.cx("fr-modal__content")}>
                                     <h1 id={titleId} className={fr.cx("fr-modal__title")}>
                                         {iconId !== undefined && (
-                                            <span className={fr.cx(iconId, "fr-fi--lg")} />
+                                            <span
+                                                className={fr.cx(iconId, "fr-fi--lg")}
+                                                aria-hidden={true}
+                                            />
                                         )}
                                         {title}
                                     </h1>


### PR DESCRIPTION
### Description
In the Modal component, the icon is missing an attribute "aria-hidden" for the screen readers as it is purely decorative