### PR TITLE
fix(Tile): do not default to SVGImage to true otherwise it doesn't work with standard svg

### DIFF
--- a/src/Tile.tsx
+++ b/src/Tile.tsx
@@ -91,7 +91,7 @@ export const Tile = memo(
             imageAlt,
             imageWidth,
             imageHeight,
-            imageSvg = true,
+            imageSvg,
             orientation = "vertical",
             small = false,
             noBorder = false,

--- a/src/Tile.tsx
+++ b/src/Tile.tsx
@@ -91,7 +91,7 @@ export const Tile = memo(
             imageAlt,
             imageWidth,
             imageHeight,
-            imageSvg,
+            imageSvg = false,
             orientation = "vertical",
             small = false,
             noBorder = false,

--- a/stories/Tile.stories.tsx
+++ b/stories/Tile.stories.tsx
@@ -111,8 +111,9 @@ const { meta, getStory } = getStoryFactory({
             }
         },
         "imageSvg": {
-            "description": "Set to true if the image is a SVG.",
-            "defaultValue": true,
+            "description":
+                "Set to true if the image is type of SVG [Pictogramme DSFR](https://www.systeme-de-design.gouv.fr/fondamentaux/pictogramme/) compliant.",
+            "defaultValue": false,
             "control": {
                 "type": "boolean"
             },


### PR DESCRIPTION
⚠️ This would be a breaking change as the option `imageSvg` will not default to `true` anymore.

The reason for that change is that, as it stands, the `Tile` component is not usable with standard SVG or other image format unless the property `imageSvg={false}` is set

