### PR TITLE
feat(button): add the onClick attribute on link

### DIFF
--- a/src/link.tsx
+++ b/src/link.tsx
@@ -18,6 +18,7 @@ export type RegisteredLinkProps = RegisterLink extends { Link: infer Link }
           | Omit<UnpackProps<Link>, "children">
           | (Omit<HTMLAnchorProps, "children" | "href"> & {
                 href: string;
+                onClick: React.MouseEventHandler<HTMLAnchorElement>;
             })
     : Omit<HTMLAnchorProps, "children">;
 


### PR DESCRIPTION
On souhaite pouvoir suivre les clicks sur nos liens. Pour cela, on utilise le onClick sur l'attribut HTML pour alerter notre solution de tracking.

Je pense qu'ajouter la possibilité de définir le onClick sur un button de type lien est une bonne chose.