### PR TITLE
feat(summary): add subitems

### DIFF
--- a/stories/Summary.stories.tsx
+++ b/stories/Summary.stories.tsx
@@ -17,27 +17,41 @@ export const Default = getStory({
     links: [
         {
             linkProps: { href: "#" },
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 1",
+            subLinks: [
+                {
+                    linkProps: { href: "#" },
+                    text: "Titre de l’ancre 1.1"
+                }
+            ]
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 2"
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 3"
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 4",
+            subLinks: [
+                {
+                    linkProps: { href: "#" },
+                    text: "Titre de l’ancre 4.1",
+                    subLinks: [
+                        {
+                            linkProps: { href: "#" },
+                            text: "Titre de l’ancre 4.1.1"
+                        }
+                    ]
+                }
+            ]
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 5"
         }
     ]
 });
@@ -47,27 +61,41 @@ export const SummaryWithCustomTitle = getStory({
     links: [
         {
             linkProps: { href: "#" },
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 1",
+            subLinks: [
+                {
+                    linkProps: { href: "#" },
+                    text: "Titre de l’ancre 1.1"
+                }
+            ]
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 2"
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 3"
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 4",
+            subLinks: [
+                {
+                    linkProps: { href: "#" },
+                    text: "Titre de l’ancre 4.1",
+                    subLinks: [
+                        {
+                            linkProps: { href: "#" },
+                            text: "Titre de l’ancre 4.1.1"
+                        }
+                    ]
+                }
+            ]
         },
         {
             linkProps: { href: "#" },
-
-            text: "Titre de l’ancre"
+            text: "Titre de l’ancre 5"
         }
     ]
 });


### PR DESCRIPTION
Évolution suite à l'issue #330

Il y a un comportement d'espacement entre les éléments profonds et le reste du sommaire qui est problématique, mais il est causé par le DSFR en lui-même. J'ai donc créé un [ticket de suggestion](https://systeme-de-design.featureupvote.com/suggestions/590786/conserver-un-espace-constant-entre-les-elements-dans-le-composant-sommaire)