### PR TITLE
feat(Card): add disabled parameter for Card component

### DIFF
--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -61,6 +61,7 @@ export type CardProps = {
             string
         >
     >;
+    disabled?: boolean;
     style?: CSSProperties;
 } & (CardProps.EnlargedLink | CardProps.NotEnlargedLink) &
     (CardProps.Horizontal | CardProps.Vertical) &
@@ -145,6 +146,7 @@ export const Card = memo(
             shadow = false,
             grey = false,
             iconId,
+            disabled = false,
             style,
             ...rest
         } = props;
@@ -198,7 +200,9 @@ export const Card = memo(
                             {linkProps !== undefined ? (
                                 <Link
                                     {...linkProps}
+                                    href={disabled ? undefined : linkProps.href}
                                     className={cx(linkProps.className, classes.link)}
+                                    aria-disabled={disabled}
                                 >
                                     {title}
                                 </Link>

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -111,6 +111,13 @@ const { meta, getStory } = getStoryFactory({
             "description": "Card content zone with grey background",
             "defaultValue": false,
             "type": "boolean"
+        },
+        "disabled": {
+            "description": "Set to true if the Tile should be disabled.",
+            "control": {
+                "type": "boolean"
+            },
+            "type": "boolean"
         }
     },
     "disabledProps": ["lang"]

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -113,7 +113,7 @@ const { meta, getStory } = getStoryFactory({
             "type": "boolean"
         },
         "disabled": {
-            "description": "Set to true if the Tile should be disabled.",
+            "description": "Set to true if the Card should be disabled.",
             "control": {
                 "type": "boolean"
             },


### PR DESCRIPTION
The parameter "disabled" only exists for Tiles. It would be great to also add it to Cards.