### PR TITLE
fix: W3C html semantic errors

### DIFF
--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -375,7 +375,7 @@ export const Header = memo(
                                                     )}
                                                 >
                                                     <button
-                                                        id={`${id}-search-button`}
+                                                        id={`${id}-search-close-button`}
                                                         className={fr.cx("fr-btn--close", "fr-btn")}
                                                         aria-controls={searchModalId}
                                                         title={t("close")}

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -160,7 +160,7 @@ export const Input = memo(
                                 classes.nativeInputOrTextArea
                             )}
                             disabled={disabled || undefined}
-                            aria-describedby={messageId}
+                            aria-describedby={state !== "default" ? messageId : undefined}
                             type={textArea ? undefined : nativeInputProps?.type ?? "text"}
                             id={inputId}
                         />

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -62,7 +62,6 @@ const Modal = memo(
         return (
             <dialog
                 aria-labelledby={titleId}
-                role="dialog"
                 id={id}
                 className={cx(fr.cx("fr-modal", topAnchor && "fr-modal--top"), className)}
                 style={style}


### PR DESCRIPTION
Correction d'erreurs sémantiques remonté par l'outil d'analyse https://validator.w3.org/ sur notre site :

https://validator.w3.org/nu/?doc=https%3A%2F%2Fcode-du-travail-numerique-preprod.ovh.fabrique.social.gouv.fr%2Fmentions-legales

Il y a 3 erreurs corrigées :

![image](https://github.com/user-attachments/assets/96f2caae-3673-45d5-80da-25abd58985a1)

Le role dialog sur une dialog n'est pas requis car implicite avec la balise dialog. Pour moi, ce devrait être un warning mais ça remonte en erreur.

![image](https://github.com/user-attachments/assets/f3b67d45-caff-4d44-ad0f-e89797d7fcdc)

Ici on utilise deux fois le même id. Je pense que c'est une erreur de copier/coller car le second id est sur un bouton pour fermer la recherche. Je l'ai donc renommé pour que ça corresponde à son role.

![image](https://github.com/user-attachments/assets/3684df8d-f57d-4293-8100-7c1506c3899e)

On ajoute aria-describedby sur l'input même si l'on a pas de message descriptif.