### PR TITLE
fix: tooltip button type shouldn't be submit

### DIFF
--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -62,6 +62,7 @@ export const Tooltip = memo(
                         className={fr.cx("fr-btn--tooltip", "fr-btn")}
                         aria-describedby={id}
                         id={`tooltip-owner-${id}`}
+                        type="button"
                     >
                         {t("tooltip-button-text")}
                     </button>


### PR DESCRIPTION
Hello,

The default type on a button is "submit". This cause problems when the tooltip is used in a form since clicking on the tooltip will cause a submit of the form.
Just setting the type on the button to type="button" will fix this.