### PR TITLE
fix(Footer): change partners heading level

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -350,14 +350,14 @@ export const Footer = memo(
                     </div>
                     {partnersLogos !== undefined && (
                         <div className={cx(fr.cx("fr-footer__partners"), classes.partners)}>
-                            <h4
+                            <h2
                                 className={cx(
                                     fr.cx("fr-footer__partners-title"),
                                     classes.partnersTitle
                                 )}
                             >
                                 {t("our partners")}
-                            </h4>
+                            </h2>
                             <div
                                 className={cx(
                                     fr.cx("fr-footer__partners-logos"),


### PR DESCRIPTION
Official DSFR documentation switched partners heading level from h4 to h2 to prevent gaps in heading levels.

This heading level doesn't have to be customized.

For additional context, I raised this issue on slack last year : https://gouvfr.slack.com/archives/C012RFZPTRN/p1691743144369259

HeadingMaps capture showing the issue with h4 on a random page : 
![image](https://github.com/user-attachments/assets/0bf743df-7f7e-43a9-b6d9-54075f3e1362)
