### PR TITLE
feat: add id on anchor tags for analytics

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -340,6 +340,7 @@ export const Footer = memo(
                                             target="_blank"
                                             href={`https://${domain}`}
                                             title={`${domain} - ${t("open new window")}`}
+                                            id={`footer-${domain.replace(/\./g, "-")}-link`}
                                         >
                                             {domain}
                                         </a>
@@ -557,6 +558,7 @@ const { useTranslation, addFooterTranslations } = createComponentI18nApi({
                     href={p.licenseUrl}
                     target="_blank"
                     title="licence etalab-2.0 - ouvre une nouvelle fenêtre"
+                    id="footer-etalab-licence-link"
                 >
                     licence etalab-2.0
                 </a>

--- a/src/SkipLinks.tsx
+++ b/src/SkipLinks.tsx
@@ -13,6 +13,7 @@ export type SkipLinksProps = {
     links: {
         label: string;
         anchor: string;
+        id?: string;
     }[];
     classes?: Partial<Record<"root" | "list" | "link", string>>;
     style?: CSSProperties;
@@ -46,6 +47,7 @@ export const SkipLinks = memo(
                                     <a
                                         className={cx(fr.cx("fr-link"), classes.link)}
                                         href={link.anchor}
+                                        id={link.id}
                                     >
                                         {link.label}
                                     </a>


### PR DESCRIPTION
Hi! In the Footer component, there are a few hard-coded links but their anchor tags that don't have an id. So I added a simple code to automatically add an id to them.

And the SkipLinks component accepts a list of links but the current typed list doesn't accept an id for each of the links. So I changed the type to specify the id of each link.