### PR TITLE
feat: add a native label props on Input

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,12 +1,13 @@
 import React, {
-    memo,
-    forwardRef,
-    ReactNode,
-    useId,
-    type InputHTMLAttributes,
-    type TextareaHTMLAttributes,
+    type CSSProperties,
     type DetailedHTMLProps,
-    type CSSProperties
+    forwardRef,
+    type InputHTMLAttributes,
+    LabelHTMLAttributes,
+    memo,
+    ReactNode,
+    type TextareaHTMLAttributes,
+    useId
 } from "react";
 import { symToStr } from "tsafe/symToStr";
 import { assert } from "tsafe/assert";
@@ -50,6 +51,10 @@ export namespace InputProps {
             InputHTMLAttributes<HTMLInputElement>,
             HTMLInputElement
         >;
+        nativeLabelProps?: DetailedHTMLProps<
+            LabelHTMLAttributes<HTMLInputElement>,
+            HTMLInputElement
+        >;
 
         nativeTextAreaProps?: never;
     };
@@ -60,6 +65,10 @@ export namespace InputProps {
         /** Props forwarded to the underlying <textarea /> element */
         nativeTextAreaProps?: DetailedHTMLProps<
             TextareaHTMLAttributes<HTMLTextAreaElement>,
+            HTMLTextAreaElement
+        >;
+        nativeLabelProps?: DetailedHTMLProps<
+            LabelHTMLAttributes<HTMLTextAreaElement>,
             HTMLTextAreaElement
         >;
 
@@ -89,6 +98,7 @@ export const Input = memo(
             nativeInputProps,
             addon,
             action,
+            nativeLabelProps,
             ...rest
         } = props;
 
@@ -137,6 +147,7 @@ export const Input = memo(
                     <label
                         className={cx(fr.cx("fr-label", hideLabel && "fr-sr-only"), classes.label)}
                         htmlFor={inputId}
+                        {...(nativeLabelProps as {})}
                     >
                         {label}
                         {hintText !== undefined && <span className="fr-hint-text">{hintText}</span>}

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,13 +1,13 @@
 import React, {
+    memo,
+    forwardRef,
+    useId,
     type CSSProperties,
     type DetailedHTMLProps,
-    forwardRef,
     type InputHTMLAttributes,
-    LabelHTMLAttributes,
-    memo,
-    ReactNode,
-    type TextareaHTMLAttributes,
-    useId
+    type LabelHTMLAttributes,
+    type ReactNode,
+    type TextareaHTMLAttributes
 } from "react";
 import { symToStr } from "tsafe/symToStr";
 import { assert } from "tsafe/assert";
@@ -51,6 +51,7 @@ export namespace InputProps {
             InputHTMLAttributes<HTMLInputElement>,
             HTMLInputElement
         >;
+        /** Props forwarded to the underlying <label /> element */
         nativeLabelProps?: DetailedHTMLProps<
             LabelHTMLAttributes<HTMLInputElement>,
             HTMLInputElement
@@ -67,6 +68,7 @@ export namespace InputProps {
             TextareaHTMLAttributes<HTMLTextAreaElement>,
             HTMLTextAreaElement
         >;
+        /** Props forwarded to the underlying <label /> element */
         nativeLabelProps?: DetailedHTMLProps<
             LabelHTMLAttributes<HTMLTextAreaElement>,
             HTMLTextAreaElement


### PR DESCRIPTION
Sometimes, we need to add properties to the label for accessibility purposes. In our case, we need to add an ID to meet autocomplete accessibility requirements.