### PR TITLE
fix(info): remove blue color for all the question

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -79,7 +79,7 @@ export const Select = memo(
                                     return "fr-select-group--error";
                                 case "success":
                                     return "fr-select-group--valid";
-                                case "default":
+                                case "default" | "info":
                                     return undefined;
                             }
                             assert<Equals<typeof state, never>>(false);

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -79,8 +79,6 @@ export const Select = memo(
                                     return "fr-select-group--error";
                                 case "success":
                                     return "fr-select-group--valid";
-                                case "info":
-                                    return "fr-select-group--info";
                                 case "default":
                                     return undefined;
                             }

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -79,7 +79,8 @@ export const Select = memo(
                                     return "fr-select-group--error";
                                 case "success":
                                     return "fr-select-group--valid";
-                                case "default" | "info":
+                                case "default":
+                                case "info":
                                     return undefined;
                             }
                             assert<Equals<typeof state, never>>(false);

--- a/src/shared/Fieldset.tsx
+++ b/src/shared/Fieldset.tsx
@@ -115,7 +115,7 @@ export const Fieldset = memo(
                         orientation === "horizontal" && "fr-fieldset--inline",
                         (() => {
                             switch (state) {
-                                case "default":
+                                case "default" | "info":
                                     return undefined;
                                 case "error":
                                     return "fr-fieldset--error";

--- a/src/shared/Fieldset.tsx
+++ b/src/shared/Fieldset.tsx
@@ -115,7 +115,8 @@ export const Fieldset = memo(
                         orientation === "horizontal" && "fr-fieldset--inline",
                         (() => {
                             switch (state) {
-                                case "default" | "info":
+                                case "default":
+                                case "info":
                                     return undefined;
                                 case "error":
                                     return "fr-fieldset--error";

--- a/src/shared/Fieldset.tsx
+++ b/src/shared/Fieldset.tsx
@@ -121,8 +121,6 @@ export const Fieldset = memo(
                                     return "fr-fieldset--error";
                                 case "success":
                                     return "fr-fieldset--valid";
-                                case "info":
-                                    return "fr-fieldset--info";
                             }
                         })()
                     ),


### PR DESCRIPTION
Bonjour,

En rajoutant la possibilité de mettre des bulles infos, j'ai induit une incohérence graphique sur le repository.

Le but étant que lorsqu'on passe le state `info`, qu'il y ait uniquement le message en bas qui s'affiche en bleu et non tout l'input, comme ce que je vous partage ci-dessous.

<img width="747" alt="Screenshot 2025-02-10 at 20 41 12" src="https://github.com/user-attachments/assets/d4d8f8e4-46c7-4c6e-8237-a30a01389c81" />

<img width="1294" alt="Screenshot 2025-02-10 at 20 41 27" src="https://github.com/user-attachments/assets/e6ae0db3-6307-4e77-9508-d83e25a56c9c" />

Merci ☺️