### PR TITLE
Add type array of string for name of PieChart

### DIFF
--- a/src/Chart/PieChart.tsx
+++ b/src/Chart/PieChart.tsx
@@ -24,7 +24,7 @@ declare global {
 
 export type PieChartBaseProps = {
     fill?: boolean;
-				name?: string[];
+    name?: string[];
 } & ChartProps;
 
 export type PieChartProps = PieChartBaseProps & BaseChartProps;

--- a/src/Chart/PieChart.tsx
+++ b/src/Chart/PieChart.tsx
@@ -24,6 +24,7 @@ declare global {
 
 export type PieChartBaseProps = {
     fill?: boolean;
+				name?: string[];
 } & ChartProps;
 
 export type PieChartProps = PieChartBaseProps & BaseChartProps;

--- a/src/Chart/PieChart.tsx
+++ b/src/Chart/PieChart.tsx
@@ -5,10 +5,11 @@ import "@gouvfr/dsfr-chart/PieChart/pie-chart.common";
 import "@gouvfr/dsfr-chart/PieChart/pie-chart.css";
 import {
     chartWrapper,
-    ChartProps,
-    IntrinsicGraphType,
-    BaseChartProps,
-    stringifyObjectValue
+    type ChartProps,
+    type IntrinsicGraphType,
+    type BaseChartProps,
+    stringifyObjectValue,
+    type ChartColor
 } from "./chartWrapper";
 
 declare global {
@@ -25,7 +26,8 @@ declare global {
 export type PieChartBaseProps = {
     fill?: boolean;
     name?: string[];
-} & ChartProps;
+    color: ChartColor[];
+} & Omit<ChartProps, "name" | "color">;
 
 export type PieChartProps = PieChartBaseProps & BaseChartProps;
 

--- a/stories/charts/PieChart.stories.tsx
+++ b/stories/charts/PieChart.stories.tsx
@@ -22,8 +22,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "y": {
             "description": "Array of value for the y axis"
         },
-        "name": { "description": "Array of name", control: "object" },
-        "color": { "description": "Array of color", control: "object" },
+        "name": { "description": "Array of name" },
+        "color": { "description": "Array of color" },
         "fill": { control: "boolean" }
     },
     "disabledProps": ["lang"]
@@ -33,5 +33,7 @@ export default meta;
 
 export const Default = getStory({
     x: [1, 2, 3],
-    y: [10, 20, 30]
+    y: [10, 20, 30],
+    name: ["Serie 1", "Serie 2", "Serie 3"],
+    color: ["blue-france", "green-bourgeon", "blue-ecume"]
 });


### PR DESCRIPTION
### Description
Cette Pull Request corrige le problème de type du name du composant PieChart. Le graphique camembert affiche plusieurs séries suivant leurs proportions et il faut pouvoir nommer ces séries.
Même si dans la documentation il est bien indiqué que c'est un Array of name, comme le PieChartBaseProps est basé sur le ChartProps et que ce dernier a comme type name?: string, il n'est pas possible de mettre un tableau et donc de nommer les différentes séries

Fixes #370 

### Changements
Le type ```ChartProps = {
    x: any[];
    y: number[];
    name?: string;
    color?: ChartColor;
};``` est utilisé par plusieurs composants donc il n'a pas été modifié, nous avons plutôt ajouter le type dans ```
PieChartBaseProps = {
    fill?: boolean;
				name?: string[];
} & ChartProps;```
