### PR TITLE
Add folder Chart in path when the component is a chart

### DIFF
--- a/stories/charts/BarChart.stories.tsx
+++ b/stories/charts/BarChart.stories.tsx
@@ -37,7 +37,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "vlinecolor": { "description": "Color of the horizontal lines", control: "object" },
         "hlinecolor": { "description": "Color of the vertical lines", control: "object" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/BarLineChart.stories.tsx
+++ b/stories/charts/BarLineChart.stories.tsx
@@ -34,7 +34,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "vlinecolor": { "description": "Color of the horizontal lines", control: "object" },
         "hlinecolor": { "description": "Color of the vertical lines", control: "object" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/GaugeChart.stories.tsx
+++ b/stories/charts/GaugeChart.stories.tsx
@@ -29,7 +29,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
             "description": "Color"
         }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/LineChart.stories.tsx
+++ b/stories/charts/LineChart.stories.tsx
@@ -31,7 +31,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "vlinecolor": { "description": "Color of the horizontal lines", control: "object" },
         "hlinecolor": { "description": "Color of the vertical lines", control: "object" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/MultiLineChart.stories.tsx
+++ b/stories/charts/MultiLineChart.stories.tsx
@@ -31,7 +31,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "vlinecolor": { "description": "Color of the horizontal lines", control: "object" },
         "hlinecolor": { "description": "Color of the vertical lines", control: "object" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/PieChart.stories.tsx
+++ b/stories/charts/PieChart.stories.tsx
@@ -26,7 +26,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "color": { "description": "Array of color", control: "object" },
         "fill": { control: "boolean" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/RadarChart.stories.tsx
+++ b/stories/charts/RadarChart.stories.tsx
@@ -25,7 +25,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "name": { "description": "Array of name", control: "object" },
         "color": { "description": "Array of color", control: "object" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/charts/ScatterChart.stories.tsx
+++ b/stories/charts/ScatterChart.stories.tsx
@@ -31,7 +31,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "vlinecolor": { "description": "Color of the horizontal lines", control: "object" },
         "hlinecolor": { "description": "Color of the vertical lines", control: "object" }
     },
-    "disabledProps": ["lang"]
+    "disabledProps": ["lang"],
+    isChartComponent: true
 });
 
 export default meta;

--- a/stories/getStory.tsx
+++ b/stories/getStory.tsx
@@ -29,6 +29,7 @@ export function getStoryFactory<Props extends Record<string, any>>(params: {
     disabledProps?: ("containerWidth" | "lang" | "darkMode")[];
     /** Default false */
     doHideImportInstruction?: boolean;
+    isChartComponent?: boolean;
 }) {
     const {
         sectionName,
@@ -37,7 +38,8 @@ export function getStoryFactory<Props extends Record<string, any>>(params: {
         argTypes = {},
         defaultContainerWidth,
         disabledProps = [],
-        doHideImportInstruction = false
+        doHideImportInstruction = false,
+        isChartComponent = false
     } = params;
 
     const Component: any = Object.entries(wrappedComponent).map(([, component]) => component)[0];
@@ -138,6 +140,8 @@ export function getStoryFactory<Props extends Record<string, any>>(params: {
 
     const componentName = symToStr(wrappedComponent);
 
+    const pathComponent = isChartComponent ? `Chart/${componentName}` : componentName;
+
     return {
         "meta": id<Meta>({
             "title": `${sectionName}/${componentName}`,
@@ -151,7 +155,7 @@ export function getStoryFactory<Props extends Record<string, any>>(params: {
                                 : [
                                       `\`\`\`tsx  `,
                                       `  `,
-                                      `import { ${componentName} } from "@codegouvfr/react-dsfr/${componentName}";`,
+                                      `import { ${componentName} } from "@codegouvfr/react-dsfr/${pathComponent}";`,
                                       ` `,
                                       `\`\`\``
                                   ]),


### PR DESCRIPTION
### Description
Cette Pull Request ajoute une partie du chemin manquante aux stories qui concernent les composants Charts.
Ces composants sont présents dans le répertoire /Charts mais ce répertoire est manquant dans le chemin d'import de la documentation.
Un nouveau paramètre a été créé pour identifier les composants Charts et ajouter le dossier dans le chemin d'import

Fixes #378 

### Changements
Ajout d'un paramètre isChartComponent dans la fonction getStory avec la valeur false par défaut et d'une règle qui permet d'ajouter le dossier Chart au chemin d'import si le composant est un Chart :
``` const pathComponent = isChartComponent ? `Chart/${componentName}` : componentName; ```
Ce paramètre est ajouté avec la valeur true dans toutes les stories des composants Chart