### PR TITLE
Fix: impossible to set a name for the bar in barline chart

### DIFF
--- a/src/Chart/BarLineChart.tsx
+++ b/src/Chart/BarLineChart.tsx
@@ -27,7 +27,8 @@ declare global {
 
 export type BarLineChartBaseProps = {
     ybar: number[];
-    name?: [string, string];
+    name?: string;
+    nameBar?: string;
     horizontal?: boolean;
     stacked?: boolean;
 } & Omit<ChartProps, "name"> &

--- a/src/Chart/chartWrapper.tsx
+++ b/src/Chart/chartWrapper.tsx
@@ -82,7 +82,12 @@ const typeSafeObjectEntries = <T extends Record<PropertyKey, unknown>>(
 };
 
 export const stringifyObjectValue = <T extends Record<PropertyKey, unknown>>(obj: T) =>
-    typeSafeObjectFromEntries(typeSafeObjectEntries(obj).map(([k, v]) => [k, JSON.stringify(v)]));
+    typeSafeObjectFromEntries(
+        typeSafeObjectEntries(obj).map(([k, v]) => [
+            k,
+            typeof v === "string" ? v : JSON.stringify(v)
+        ])
+    );
 
 export const chartWrapper = <T extends {}>(ChartComponent: React.FC<T>, idPrefix: string) => {
     return memo(

--- a/stories/charts/BarLineChart.stories.tsx
+++ b/stories/charts/BarLineChart.stories.tsx
@@ -25,7 +25,8 @@ You can find an example [here](https://github.com/codegouvfr/react-dsfr/blob/bc2
         "ybar": {
             "description": "Array of value for the x axis to create the bars"
         },
-        "name": { "description": "Array of name", control: "object" },
+        "name": { "description": "Name for the line", control: "object" },
+        "nameBar": { "description": "Name for the bars", control: "object" },
         "color": { "description": "Array of color", control: "object" },
         "hline": { "description": "Array of horizontal lines to add", control: "object" },
         "hlinename": { "description": "Name of the horizontal lines", control: "object" },


### PR DESCRIPTION
# Description
Cette Pull Request ajoute la possibilité de mettre un nom au Bar dans le composant BarLineChart.
Elle corrige également un problème de stringify non nécessaire lorsque que un paramètre était de type `string.` 

Fixes https://github.com/codegouvfr/react-dsfr/issues/371