### PR TITLE
Charts - PieCharts : Add undefined to color prop

### DIFF
--- a/src/Chart/PieChart.tsx
+++ b/src/Chart/PieChart.tsx
@@ -26,7 +26,7 @@ declare global {
 export type PieChartBaseProps = {
     fill?: boolean;
     name?: string[];
-    color: ChartColor[];
+    color?: ChartColor[];
 } & Omit<ChartProps, "name" | "color">;
 
 export type PieChartProps = PieChartBaseProps & BaseChartProps;


### PR DESCRIPTION
### Description

Cette Pull Request est la suite de la #377. La propriété color a été ajoutée dans le PieChartBaseProps mais en la rendant obligatoire. 
Nous proposons d'ajouter la possibilité qu'elle soit undefined et ainsi de prendre les couleurs par défaut.

J'en profite pour vous indiquer qu'une nouvelle version 2.0.0 de DSFR-Charts est sortie hier :
https://github.com/GouvernementFR/dsfr-chart/releases/tag/v2.0.0

Cette version est active et est amenée à évoluer au cours de l'année. Je vais voir si la migration se fait simplement et je vous tiendrai au courant

Fixes #384 

### Explication

Comme pour les autres propriétés, un ? a été ajouté pour que la propriété color puisse être undefined :
```color?: ChartColor[];```