### PR TITLE
feat(BackToTop): add a BackToTop component

### DIFF
--- a/src/BackToTop/BackToTop.tsx
+++ b/src/BackToTop/BackToTop.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { forwardRef, memo } from "react";
+import { getLink } from "../link";
+import { cx } from "../tools/cx";
+import { fr, FrCxArg } from "../fr";
+
+const TOP_ID = "#top";
+
+export enum BTT_Placement {
+    LEFT = "left",
+    CENTER = "center",
+    RIGHT = "right"
+}
+
+const classByPlacement: Record<BTT_Placement, FrCxArg> = {
+    [BTT_Placement.LEFT]: "fr-grid-row--left",
+    [BTT_Placement.CENTER]: "fr-grid-row--center",
+    [BTT_Placement.RIGHT]: "fr-grid-row--right"
+};
+
+export type BackToTopProps = {
+    id?: string;
+    className?: string;
+    placement?: BTT_Placement;
+    animated?: boolean;
+    value?: string;
+};
+
+/**
+ * Scroll to the top of the page with a smooth animation if user didn't enabled reduced motion for accessibility.
+**/
+function scrollToTop() {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const behavior = prefersReducedMotion ? "auto" : "smooth";
+    const topElement = document.querySelector(TOP_ID) as HTMLElement | null;
+
+    if (topElement) {
+        history.pushState(null, "", TOP_ID);
+        topElement.scrollIntoView({
+            behavior: behavior,
+            block: "start"
+        });
+
+        topElement.setAttribute("tabindex", "-1");
+        topElement.focus();
+    } else {
+        window.scrollTo({ top: 0, behavior: behavior });
+    }
+}
+
+/** @see <https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/retour-en-haut-de-page> */
+export const BackToTop = memo(
+    forwardRef<HTMLAnchorElement, BackToTopProps>(
+        (
+            {
+                id: props_id,
+                className: props_className,
+                placement = BTT_Placement.LEFT,
+                animated = true,
+                value = "Haut de page",
+                ...rest
+            },
+            ref
+        ) => {
+            const { Link } = getLink();
+
+            const linkClassName = cx(
+                fr.cx("fr-link", "fr-icon-arrow-up-fill", "fr-link--icon-left"),
+                props_className
+            );
+
+            const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+                if (!animated) return;
+                event.preventDefault();
+                scrollToTop();
+            };
+
+            return (
+                <div className={fr.cx("fr-grid-row", classByPlacement[placement])}>
+                    <Link
+                        id={props_id}
+                        className={linkClassName}
+                        href={TOP_ID}
+                        ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+                        onClick={handleClick}
+                        {...rest}
+                    >
+                        {value}
+                    </Link>
+                </div>
+            );
+        }
+    )
+);
+
+export default BackToTop;

--- a/src/BackToTop/index.ts
+++ b/src/BackToTop/index.ts
@@ -1,0 +1,1 @@
+export * from "./BackToTop";

--- a/stories/BackToTop.stories.tsx
+++ b/stories/BackToTop.stories.tsx
@@ -1,0 +1,45 @@
+import { getStoryFactory } from "./getStory";
+import { BackToTop, BackToTopProps, BTT_Placement } from "../src/BackToTop";
+
+const storyDescription = `
+- [See DSFR documentation](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/retour-en-haut-de-page)
+- [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/BackToTop/BackToTop.tsx)`;
+
+
+const { meta, getStory } = getStoryFactory<BackToTopProps>({
+    sectionName: "Components",
+    wrappedComponent: { BackToTop },
+    description: storyDescription,
+    argTypes: {
+        id: { control: "text", description: "ID de l'élément" },
+        className: { control: "text", description: "Classes CSS supplémentaires" },
+        value: { control: "text", description: "Texte du lien" },
+    },
+    disabledProps: ["lang", "containerWidth"]
+});
+
+export default meta;
+
+export const Default = getStory({
+    id: "back-to-top-default",
+});
+
+export const Center = getStory({
+    id: "back-to-top-center",
+    placement: BTT_Placement.CENTER,
+});
+
+export const Right = getStory({
+    id: "back-to-top-center",
+    placement: BTT_Placement.RIGHT,
+});
+
+export const CustomText = getStory({
+    id: "back-to-top-custom",
+    value: "Vers l'infini et au-delà 🚀",
+});
+
+export const NotAnimated = getStory({
+    id: "back-to-top-no-animation",
+    animated: false,
+});


### PR DESCRIPTION
Here is my implementation of the component BackToTop "Retour en haut de page - Back to top".

I followed the instructions documented [here](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/retour-en-haut-de-page) 

The only liberty i took is adding an optional animation feature and allowing developper to override the default text value.

The animation depend on the `animated` property and check if the user activated the prefers-reduced-motion browser parameter for accessibility concerns