### PR TITLE
fix(SideMenu): Don't include aria-labelledby when no title exists

### DIFF
--- a/src/SideMenu.tsx
+++ b/src/SideMenu.tsx
@@ -91,7 +91,7 @@ export const SideMenu = memo(
                 {...rest}
                 ref={ref}
                 style={style}
-                aria-labelledby={titleId}
+                {...(title !== undefined && { "aria-labelledby": titleId })}
                 className={cx(
                     fr.cx("fr-sidemenu", {
                         "fr-sidemenu--right": align === "right",

--- a/stories/SideMenu.stories.tsx
+++ b/stories/SideMenu.stories.tsx
@@ -307,3 +307,18 @@ export const SideMenuWith3Levels = getStory({
         }
     ]
 });
+
+export const SideMenuWithNoTitle = getStory({
+    "burgerMenuButtonText": "Dans cette rubrique",
+    "items": [
+        {
+            "isActive": true,
+            "text": "Accès direct",
+            "linkProps": { "href": "#" }
+        },
+        {
+            "text": "Accès direct",
+            "linkProps": { "href": "#" }
+        }
+    ]
+});


### PR DESCRIPTION
Issue found with an accessibility tool while auditing my site :-)

Thanks for react-dsfr!