### PR TITLE
feat: :lipstick: Wrap dsfr css imports in a dsfr layer

### DIFF
--- a/src/assets/dsfr_plus_icons.css
+++ b/src/assets/dsfr_plus_icons.css
@@ -1,3 +1,3 @@
 
-@import url('../dsfr/utility/icons/icons.min.css');
-@import url('../dsfr/dsfr.min.css');
+@import url('../dsfr/utility/icons/icons.min.css') layer(dsfr);
+@import url('../dsfr/dsfr.min.css') layer(dsfr);

--- a/src/assets/dsfr_plus_icons.scss
+++ b/src/assets/dsfr_plus_icons.scss
@@ -1,2 +1,4 @@
-@use '../dsfr/utility/icons/icons.min.css';
-@use '../dsfr/dsfr.min.css';
+@layer dsfr {
+  @use '../dsfr/utility/icons/icons.min.css';
+  @use '../dsfr/dsfr.min.css';
+}

--- a/src/assets/dsfr_plus_icons.scss
+++ b/src/assets/dsfr_plus_icons.scss
@@ -1,4 +1,2 @@
-@layer dsfr {
-  @use '../dsfr/utility/icons/icons.min.css';
-  @use '../dsfr/dsfr.min.css';
-}
+@use '../dsfr/utility/icons/icons.min.css';
+@use '../dsfr/dsfr.min.css';


### PR DESCRIPTION
This PR just wraps the included dsfr css in a dsfr layer.  This allows codebases that are using the nextjs pages dir to better prioritize the dsfr css with respect to their own or third party libraries.

For example, at Réfugiés.info, we have a legacy codebase with several different frameworks historically including for example some bootstrap.  We use a @layers directive to help prioritize these different and sometimes conflicting css files.

https://github.com/refugies-info/karfur/blob/89b999a95d7d547a3f0749da41c7e17a0d7379f7/apps/client/src/css/index.css#L1

Since react-dsfr imports dsfr.min.css in the Next Pages Router integration:

https://github.com/codegouvfr/react-dsfr/blob/16f7f11ecc370b330016044ccdb3664b25c9ad5a/src/next-pagesdir.tsx#L24

We currently resort to patching the dsfr.min.css file, however this requires updating the patch for each new react-dsfr release, which is not ideal.

https://github.com/refugies-info/karfur/blob/89b999a95d7d547a3f0749da41c7e17a0d7379f7/package.json#L26