### PR TITLE
fix(SelectNext): No generation of aria-describedby referencing a non-existant id in the case of a default state (#402)

### DIFF
--- a/src/SelectNext.tsx
+++ b/src/SelectNext.tsx
@@ -174,9 +174,11 @@ function NonMemoizedNonForwardedSelect<T extends SelectProps.Option[]>(
                 className={cx(fr.cx("fr-select"), nativeSelectProps.className)}
                 id={selectId}
                 aria-describedby={
-                    nativeSelectProps["aria-describedby"] !== undefined
+                    state !== "default" && nativeSelectProps["aria-describedby"] !== undefined
                         ? `${stateDescriptionId} ${nativeSelectProps["aria-describedby"]}`
-                        : stateDescriptionId
+                        : state !== "default"
+                        ? stateDescriptionId
+                        : undefined
                 }
                 disabled={disabled}
             >


### PR DESCRIPTION
Voici une proposition de Pull Request pour venir corriger l'issue : [#402](https://github.com/codegouvfr/react-dsfr/issues/402).

Le travail a été réalisé par [MBrandone](https://github.com/MBrandone) pour le [Select](https://github.com/codegouvfr/react-dsfr/blob/main/src/Select.tsx) dans la PR suivante : [#403](https://github.com/codegouvfr/react-dsfr/pull/403) mais le problème est toujours présent sur le [SelectNext](https://github.com/codegouvfr/react-dsfr/blob/main/src/SelectNext.tsx).

La correction consiste donc à ne pas avoir l'attribut aria-describedby sur l'élément select quand il possède un state à "default" car aucun élément avec cet ID dans le DOM ne lui est associé.