### PR TITLE
Revert "feat: :lipstick: Wrap dsfr css imports in a dsfr layer"

### DIFF
--- a/src/assets/dsfr_plus_icons.css
+++ b/src/assets/dsfr_plus_icons.css
@@ -1,3 +1,3 @@
 
-@import url('../dsfr/utility/icons/icons.min.css') layer(dsfr);
-@import url('../dsfr/dsfr.min.css') layer(dsfr);
+@import url('../dsfr/utility/icons/icons.min.css');
+@import url('../dsfr/dsfr.min.css');


### PR DESCRIPTION
I would like to revert this PR because my tests have not been conclusive.  Indeed, it appears that [support of native CSS features](https://github.com/webpack/webpack/issues/14893) such as

`@import url("...") layer(layerName)`

is only slated for webpack 6 which hasn't been released yet.  I tried enabling these new features in the latest webpack version 5.99.8  using the `experimental.css: true` webpack config setting but this caused major breakage of our UI.

Reverts codegouvfr/react-dsfr#400

