### PR TITLE
fix: Default export on addPasswordInputTranslations for external usage

### DIFF
--- a/src/blocks/PasswordInput.tsx
+++ b/src/blocks/PasswordInput.tsx
@@ -243,6 +243,8 @@ addPasswordInputTranslations({
     }
 });
 
+export { addPasswordInputTranslations };
+
 PasswordInput.displayName = symToStr({ PasswordInput });
 
 export default PasswordInput;


### PR DESCRIPTION
In order to translate some messages in other languages than english, spanish and french. I had to add a default export onto the function 'addInputPasswordTranslations' for external uses.