### PR TITLE
Fix - Tabs component

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import React, {
-    memo,
-    forwardRef,
-    useId,
-    useState,
-    useEffect,
-    type ReactNode,
-    type CSSProperties,
-    useCallback
-} from "react";
+import React, { memo, forwardRef, useId, type ReactNode, type CSSProperties, useMemo } from "react";
 import type { FrIconClassName, RiIconClassName } from "./fr/generatedFromCss/classNames";
 import { symToStr } from "tsafe/symToStr";
 import { fr } from "./fr";
@@ -79,24 +70,14 @@ export const Tabs = memo(
             "explicitlyProvidedId": id_props
         });
 
-        const getSelectedTabIndex = () => {
+        const selectedTabIndex = useMemo(() => {
             const index = tabs.findIndex(tab =>
                 "content" in tab ? tab.isDefault ?? false : tab.tabId === selectedTabId
             );
             return index === -1 ? 0 : index;
-        };
-
-        const currentSelectedTabIndex = getSelectedTabIndex();
+        }, [tabs, selectedTabId]);
 
         const buttonRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
-
-        const [selectedTabIndex, setSelectedTabIndex] = useState<number>(currentSelectedTabIndex);
-
-        useEffect(() => {
-            if (selectedTabId) {
-                setSelectedTabIndex(currentSelectedTabIndex);
-            }
-        }, [selectedTabId, currentSelectedTabIndex]);
 
         const onTabClickFactory = useCallbackFactory(([tabIndex]: [number]) => {
             if (selectedTabId === undefined) {


### PR DESCRIPTION
I noticed that at certain times, when we have tabs loaded asynchronously, the selected tab is not the correct one. For example, if we have 3 tabs, the second one is loaded asynchronously, and we have selected the third one, in the end, the second tab is the one selected in the interface.

I made a more simple approach (using useMemo instead of useState + useEffect), which works fine with both sync and async generated tabs.
