### PR TITLE
feat(Footer): lien service-public.gouv.fr

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -172,7 +172,12 @@ export const Footer = memo(
             style,
             linkList,
             linkListTitle,
-            domains = ["info.gouv.fr", "service-public.fr", "legifrance.gouv.fr", "data.gouv.fr"],
+            domains = [
+                "info.gouv.fr",
+                "service-public.gouv.fr",
+                "legifrance.gouv.fr",
+                "data.gouv.fr"
+            ],
             ...rest
         } = props;
 


### PR DESCRIPTION
Renomme `service-public.fr` en `service-public.gouv.fr`

La nouvelle URL est fonctionnelle et sera recommandée dans la documentation du DSFR 1.14.2 (voir https://github.com/GouvernementFR/dsfr/pull/1295)