### PR TITLE
Fix : removing DescriptionTag if description not provided

### DIFF
--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -156,7 +156,7 @@ export const Alert = memo(
                         {title}
                     </HtmlTitleTag>
                 )}
-                {description && (
+                {description !== undefined && (
                     <DescriptionTag className={classes.description}>{description}</DescriptionTag>
                 )}
                 {isClosableByUser && (


### PR DESCRIPTION
# Description
During an RGAA audit, it's been pointed out that there was an empty p/div whenever the description was empty.
The DescriptionTag node was being rendered even if the description property wasn't provided.

# Fix
Don't render the DescriptionTag if description isn't provided