### PR TITLE
fix(modal): ajout de la possibilité de définir un `titleAs` sur le composant

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -102,7 +102,7 @@ const Modal = memo(
                                     <TitleTag
                                         id={titleId}
                                         {...titleProps}
-                                        className={cx(titleProps.className,fr.cx("fr-modal__title"))}
+                                        className={cx(titleProps.className, fr.cx("fr-modal__title"))}
                                     >
                                         {iconId !== undefined && (
                                             <span


### PR DESCRIPTION
J’ai ajouté la possibilité de personnaliser le type de balise du titre du composant Modal, qui est actuellement fixé à h1. Suite aux recommandations de notre expert SEO, il serait intéressant d’utiliser une div avec le rôle heading et un aria-level 1 à la place afin de préserver la sémantique et l’accessibilité