### PR TITLE
fix(Alert): honour explicit role={undefined} to suppress role attribute

### DIFF
--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -74,9 +74,13 @@ export const Alert = memo(
             closable: isClosableByUser = false,
             isClosed: props_isClosed,
             onClose,
-            role = "alert",
+            role: roleFromProps,
             ...rest
         } = props;
+
+        // Honour explicit `role={undefined}` to opt out of the role attribute (RGAA 8.7).
+        // When role is omitted entirely, default to "alert" for screen reader announcements.
+        const role = "role" in props ? roleFromProps : ("alert" as const);
 
         assert<Equals<keyof typeof rest, never>>();
 
@@ -147,8 +151,8 @@ export const Alert = memo(
                     className
                 )}
                 style={style}
-                {...(refShouldSetRole.current && { "role": role })}
-                {...(role ? { "role": role } : {})}
+                {...(refShouldSetRole.current && role !== undefined && { "role": role })}
+                {...(role !== undefined ? { "role": role } : {})}
                 ref={ref}
                 {...rest}
             >

--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -94,7 +94,6 @@ export const Alert = memo(
         const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null);
 
         const refShouldButtonGetFocus = useRef(false);
-        const refShouldSetRole = useRef(false);
         const DescriptionTag = typeof description === "string" ? "p" : "div";
 
         useEffect(() => {
@@ -104,7 +103,6 @@ export const Alert = memo(
             setIsClosed(isClosed => {
                 if (isClosed && !props_isClosed) {
                     refShouldButtonGetFocus.current = true;
-                    refShouldSetRole.current = true;
                 }
 
                 return props_isClosed;
@@ -151,7 +149,6 @@ export const Alert = memo(
                     className
                 )}
                 style={style}
-                {...(refShouldSetRole.current && role !== undefined && { "role": role })}
                 {...(role !== undefined ? { "role": role } : {})}
                 ref={ref}
                 {...rest}


### PR DESCRIPTION
Fixes #478.

## Problème

Passer `role={undefined}` sur `<Alert />` rendait quand même `role="alert"` dans le DOM, ce qui est une non-conformité RGAA (critère 8.7 — changement de contexte non demandé par l'utilisateur·rice).

La cause : le default dans le destructuring (`role = "alert"`) remplace silencieusement `undefined` par `"alert"`, même lorsque `undefined` est **explicitement** fourni par l'appelant·e.

## Correction

Au lieu d'un default dans le destructuring, on utilise `"role" in props` pour distinguer les deux cas :

- `role` **non fourni** → comportement par défaut conservé : `"alert"` (compatibilité ascendante intacte)
- `role={undefined}` **explicitement passé** → aucun attribut `role` dans le DOM rendu

```tsx
// Avant
role = "alert",

// Après
role: roleFromProps,
// ...
const role = "role" in props ? roleFromProps : ("alert" as const);
```

Le rendu JSX passe de `role ?` à `role !== undefined` pour gérer correctement la valeur `undefined` :

```tsx
// Avant
{...(role ? { "role": role } : {})}

// Après
{...(role !== undefined ? { "role": role } : {})}
```

La même correction est appliquée au spread conditionnel `refShouldSetRole` (ré-annonce par les lecteurs d'écran quand l'alerte se rouvre).

## Tests

- La pre-commit hook (ESLint + Prettier) passe sur le fichier modifié.
- Aucun nouveau warning lint introduit (`Notice.tsx` avait une warning pre-existing).
- Comportement attendu : `<Alert role={undefined} ... />` → pas d'attribut `role` dans le DOM rendu.