### PR TITLE
feat(Tabs): add ariaLabel and title props to tab buttons

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -28,6 +28,8 @@ export namespace TabsProps {
             content: ReactNode;
             isDefault?: boolean;
             disabled?: boolean;
+            ariaLabel?: string;
+            title?: string;
         }[];
         selectedTabId?: undefined;
         onTabChange?: (params: { tabIndex: number; tab: Uncontrolled["tabs"][number] }) => void;
@@ -40,6 +42,8 @@ export namespace TabsProps {
             label: ReactNode;
             iconId?: FrIconClassName | RiIconClassName;
             disabled?: boolean;
+            ariaLabel?: string;
+            title?: string;
         }[];
         selectedTabId: string;
         onTabChange: (tabId: string) => void;
@@ -141,7 +145,7 @@ export const Tabs = memo(
                     aria-label={label}
                     onKeyDownCapture={e => onKeyboardNavigation(e)}
                 >
-                    {tabs.map(({ label, iconId, disabled }, tabIndex) => (
+                    {tabs.map(({ label, iconId, disabled, ariaLabel, title }, tabIndex) => (
                         <li key={tabIndex} role="presentation">
                             <button
                                 ref={button => (buttonRefs.current[tabIndex] = button)}
@@ -157,6 +161,8 @@ export const Tabs = memo(
                                 aria-controls={getPanelId(tabIndex)}
                                 onClick={onTabClickFactory(tabIndex)}
                                 disabled={disabled}
+                                aria-label={ariaLabel}
+                                title={title}
                             >
                                 {label}
                             </button>

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -88,3 +88,25 @@ export const WithTab2OpenedByDefault = getStory({
     "label": "Name of the tabs system",
     ...logCallbacks(["onTabChange"])
 });
+
+export const WithAriaLabelAndTitle = getStory({
+    "tabs": [
+        {
+            "label": "Tab 1",
+            "iconId": "fr-icon-add-line",
+            "content": <p>Content of tab1</p>,
+            "ariaLabel": "First tab, add content",
+            "title": "Add content"
+        },
+        {
+            "label": "Tab 2",
+            "iconId": "fr-icon-ball-pen-fill",
+            "content": <p>Content of tab2</p>,
+            "ariaLabel": "Second tab, edit content",
+            "title": "Edit content"
+        },
+        { "label": "Tab 3", "content": <p>Content of tab3</p> }
+    ],
+    "label": "Tabs with aria-label and title attributes",
+    ...logCallbacks(["onTabChange"])
+});


### PR DESCRIPTION
Closes #471

Adds optional `ariaLabel` and `title` props to tab button items in both 
Uncontrolled and Controlled modes, enabling accessibility attributes 
required by RGAA and WCAG standards.

A new Storybook story `WithAriaLabelAndTitle` demonstrates the feature.