### PR TITLE
fix(Input): use fr-message classes instead of fr-error/valid/info-text

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -221,14 +221,15 @@ export const Input = memo(
                             id={messageId}
                             className={cx(
                                 fr.cx(
+                                    "fr-message",
                                     (() => {
                                         switch (state) {
                                             case "error":
-                                                return "fr-error-text";
+                                                return "fr-message--error";
                                             case "success":
-                                                return "fr-valid-text";
+                                                return "fr-message--valid";
                                             case "info":
-                                                return "fr-info-text";
+                                                return "fr-message--info";
                                         }
                                     })()
                                 ),


### PR DESCRIPTION
## Problem

The `Input` component was using legacy DSFR CSS classes for state messages:
- `.fr-error-text`
- `.fr-valid-text`
- `.fr-info-text`

These classes cause icon misalignment when the message spans multiple lines (see #480).

## Fix

Replace with the classes recommended by the official DSFR documentation:
- `.fr-message .fr-message--error`
- `.fr-message .fr-message--valid`
- `.fr-message .fr-message--info`

All three modifier classes are already present in `src/fr/generatedFromCss/classNames.ts` and correctly typed.

Closes #480
