### PR TITLE
feat(Footer): allow ReactNode for categoryName to support lang attribute

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -117,7 +117,7 @@ export namespace FooterProps {
             LinkList.Link?
         ];
         export interface Column {
-            categoryName?: string;
+            categoryName?: ReactNode;
             links: Links;
         }
         export interface Link {

--- a/stories/Footer.stories.tsx
+++ b/stories/Footer.stories.tsx
@@ -241,11 +241,28 @@ export const WithLinkList = getStory({
     "contentDescription": `
     Ce message est à remplacer par les informations de votre site.
 
-    Comme exemple de contenu, vous pouvez indiquer les informations 
+    Comme exemple de contenu, vous pouvez indiquer les informations
     suivantes : Le site officiel d’information administrative pour les entreprises.
-    Retrouvez toutes les informations et démarches administratives nécessaires à la création, 
+    Retrouvez toutes les informations et démarches administratives nécessaires à la création,
     à la gestion et au développement de votre entreprise.
     `,
     linkList,
+    linkListTitle: <h2>Liens utiles</h2>
+});
+
+export const WithLinkListAndLangOnCategoryName = getStory({
+    "accessibility": "fully compliant",
+    "contentDescription": `
+    Ce message est à remplacer par les informations de votre site.
+
+    Comme exemple de contenu, vous pouvez indiquer les informations
+    suivantes : Le site officiel d’information administrative pour les entreprises.
+    Retrouvez toutes les informations et démarches administratives nécessaires à la création,
+    à la gestion et au développement de votre entreprise.
+    `,
+    linkList: new Array(6).fill({
+        categoryName: <span lang="en">Category name</span>,
+        links
+    }) as FooterProps.LinkList.List,
     linkListTitle: <h2>Liens utiles</h2>
 });


### PR DESCRIPTION
Closes #476

widens the type of `FooterProps.LinkList.Column.categoryName` from `string` 
to `ReactNode`, allowing consumers to wrap content with a `lang` attribute 
to signal language changes in the source code, as required by RGAA 
criterion 8.7.

the change is fully backwards compatible since `string` is a valid `ReactNode`.

a new Storybook story `WithLinkListAndLangOnCategoryName` demonstrates 
the use case.