### PR TITLE
Faire du bouton du SideMenu button un button simple

### DIFF
--- a/src/SideMenu.tsx
+++ b/src/SideMenu.tsx
@@ -108,6 +108,8 @@ export const SideMenu = memo(
                         aria-expanded="false"
                         aria-controls={collapseId}
                         className={cx(fr.cx("fr-sidemenu__btn"), classes.button)}
+                        role="button"
+                        type="button"
                     >
                         {burgerMenuButtonText}
                     </button>


### PR DESCRIPTION
# Faire du bouton du SideMenu button un button simple

Correctif lié à l'issue #500 : empêcher le bouton d'affichage / masquage du `<SideMenu />` de déclencher la soumission du formulaire.