### PR TITLE
fix(bin): Don't crash only-include-used-icons when public/dsfr exists without an index.html

### DIFF
--- a/src/bin/only-include-used-icons.ts
+++ b/src/bin/only-include-used-icons.ts
@@ -117,11 +117,11 @@ type CommandContext = {
         | {
               dsfrDirPath_static: string;
               // Undefined whenever public/dsfr exists but no index.html was found to add
-              // a cache busting query parameter to: a monorepo invoked with --projectDir
-              // where the html is not where either branch looks, a project that used to be
-              // a Vite/CRA app and lost its index.html, or a public/dsfr that was committed
-              // or restored by other means. Not reachable through copy-static-assets: it
-              // asserts "Can't locate your index.html file." before creating anything.
+              // a cache busting query parameter to: a project that used to be a Vite/CRA
+              // app and lost its index.html, or a public/dsfr that was committed or
+              // restored by other means. Not reachable through copy-static-assets, which
+              // resolves index.html through the same two paths as this script and asserts
+              // "Can't locate your index.html file." before creating anything.
               htmlFilePath: string | undefined;
           }
         | undefined;

--- a/src/bin/only-include-used-icons.ts
+++ b/src/bin/only-include-used-icons.ts
@@ -117,9 +117,11 @@ type CommandContext = {
         | {
               dsfrDirPath_static: string;
               // Undefined whenever public/dsfr exists but no index.html was found to add
-              // a cache busting query parameter to: a monorepo invoked with --projectDir,
-              // a project that used to be a Vite/CRA app, or a Next.js app that opted into
-              // copy-static-assets (the documented Next.js setup has no public/dsfr at all).
+              // a cache busting query parameter to: a monorepo invoked with --projectDir
+              // where the html is not where either branch looks, a project that used to be
+              // a Vite/CRA app and lost its index.html, or a public/dsfr that was committed
+              // or restored by other means. Not reachable through copy-static-assets: it
+              // asserts "Can't locate your index.html file." before creating anything.
               htmlFilePath: string | undefined;
           }
         | undefined;

--- a/src/bin/only-include-used-icons.ts
+++ b/src/bin/only-include-used-icons.ts
@@ -477,7 +477,12 @@ export async function main(args: string[]) {
             })
         );
 
-        return { "usedIconClassNames": Array.from(setUsedIconClassNames) };
+        // NOTE: The set is filled from a Promise.all over the source files, so its
+        // insertion order follows I/O completion order and varies between runs. Sorting
+        // makes the generated stylesheet byte stable, which is what the `hasChanged`
+        // comparison below relies on. Rule order carries no meaning here: every rule
+        // targets a distinct `.fr-icon-*::before` / `.ri-*::before` selector.
+        return { "usedIconClassNames": Array.from(setUsedIconClassNames).sort() };
     })();
 
     if (usedIconClassNames.length > 300) {

--- a/src/bin/only-include-used-icons.ts
+++ b/src/bin/only-include-used-icons.ts
@@ -116,8 +116,10 @@ type CommandContext = {
     spaParams:
         | {
               dsfrDirPath_static: string;
-              // Undefined in Next.js: public/dsfr exists (copy-static-assets put it there)
-              // but there is no index.html to add a cache busting query parameter to.
+              // Undefined whenever public/dsfr exists but no index.html was found to add
+              // a cache busting query parameter to: a monorepo invoked with --projectDir,
+              // a project that used to be a Vite/CRA app, or a Next.js app that opted into
+              // copy-static-assets (the documented Next.js setup has no public/dsfr at all).
               htmlFilePath: string | undefined;
           }
         | undefined;
@@ -529,46 +531,42 @@ export async function main(args: string[]) {
             })
     );
 
-    // NOTE: Deliberately outside of the `hasChanged` guard below. The rewrite is
-    // idempotent, and inside the guard a stale or hand reverted hash could never be
-    // repaired as long as icons.min.css itself did not change.
-    await (async function addHashQueryParameterInIndexHtml() {
-        const htmlFilePath = commandContext.spaParams?.htmlFilePath;
-
-        if (htmlFilePath === undefined) {
-            return;
-        }
-
-        const html = (await readFile(htmlFilePath)).toString("utf8");
-
-        const { modifiedHtml } = modifyHtmlHrefs({
-            "html": html,
-            "getModifiedHref": href => {
-                if (!href.includes(iconsMinCssRelativePath.replace(/\\/g, "/"))) {
-                    return href;
-                }
-
-                const [urlWithoutQuery] = href.split("?");
-
-                return `${urlWithoutQuery}?hash=${fnv1aHashToHex(
-                    rawIconCssCodeBuffer.toString("utf8")
-                )}`;
-            }
-        });
-
-        if (modifiedHtml === html) {
-            return;
-        }
-
-        await writeFile(htmlFilePath, Buffer.from(modifiedHtml, "utf8"));
-    })();
-
-    if (!hasChanged) {
-        log?.("No change since last run");
-        return;
-    }
-
+    // NOTE: Deliberately outside of the `hasChanged` guard below. These three writes are
+    // idempotent, and inside the guard a stale or hand reverted output could never be
+    // repaired as long as icons.min.css itself did not change. Nothing else writes them:
+    // copy-dsfr-to-public builds its keep list from the url() of dsfr.min.css, so the
+    // icons and the hash query parameter are this script's responsibility alone.
     await Promise.all([
+        (async function addHashQueryParameterInIndexHtml() {
+            const htmlFilePath = commandContext.spaParams?.htmlFilePath;
+
+            if (htmlFilePath === undefined) {
+                return;
+            }
+
+            const html = (await readFile(htmlFilePath)).toString("utf8");
+
+            const { modifiedHtml } = modifyHtmlHrefs({
+                "html": html,
+                "getModifiedHref": href => {
+                    if (!href.includes(iconsMinCssRelativePath.replace(/\\/g, "/"))) {
+                        return href;
+                    }
+
+                    const [urlWithoutQuery] = href.split("?");
+
+                    return `${urlWithoutQuery}?hash=${fnv1aHashToHex(
+                        rawIconCssCodeBuffer.toString("utf8")
+                    )}`;
+                }
+            });
+
+            if (modifiedHtml === html) {
+                return;
+            }
+
+            await writeFile(htmlFilePath, Buffer.from(modifiedHtml, "utf8"));
+        })(),
         (async function generateUsedRemixiconFiles() {
             await Promise.all(
                 [commandContext.dsfrDirPath, commandContext.spaParams?.dsfrDirPath_static]
@@ -576,9 +574,7 @@ export async function main(args: string[]) {
                     .map(async dsfrDistDirPath => {
                         const remixiconDirPath = pathJoin(dsfrDistDirPath, "icons", "remixicon");
 
-                        if (!fs.existsSync(remixiconDirPath)) {
-                            fs.mkdirSync(remixiconDirPath);
-                        }
+                        fs.mkdirSync(remixiconDirPath, { "recursive": true });
 
                         await Promise.all(
                             usedIcons
@@ -617,29 +613,35 @@ export async function main(args: string[]) {
                     )
                     .map(([srcFilePath, destFilePath]) => cp(srcFilePath, destFilePath))
             );
-        })(),
-        (async function clearCache() {
-            await Promise.all(
-                [
-                    pathJoin(".next", "cache"),
-                    pathJoin(".vite"),
-                    pathJoin(".cache", "storybook"),
-                    pathJoin(".cache", "babel-loader"),
-                    pathJoin(".cache", "default-development")
-                ]
-                    .map(relativeDirPath =>
-                        pathJoin(commandContext.projectDirPath, "node_modules", relativeDirPath)
-                    )
-                    .map(async dirPath => {
-                        if (!(await existsAsync(dirPath))) {
-                            return;
-                        }
-
-                        await rm(dirPath, { "recursive": true, "force": true });
-                    })
-            );
         })()
     ]);
+
+    if (!hasChanged) {
+        log?.("No change since last run");
+        return;
+    }
+
+    await (async function clearCache() {
+        await Promise.all(
+            [
+                pathJoin(".next", "cache"),
+                pathJoin(".vite"),
+                pathJoin(".cache", "storybook"),
+                pathJoin(".cache", "babel-loader"),
+                pathJoin(".cache", "default-development")
+            ]
+                .map(relativeDirPath =>
+                    pathJoin(commandContext.projectDirPath, "node_modules", relativeDirPath)
+                )
+                .map(async dirPath => {
+                    if (!(await existsAsync(dirPath))) {
+                        return;
+                    }
+
+                    await rm(dirPath, { "recursive": true, "force": true });
+                })
+        );
+    })();
 }
 
 if (require.main === module) {

--- a/src/bin/only-include-used-icons.ts
+++ b/src/bin/only-include-used-icons.ts
@@ -116,7 +116,9 @@ type CommandContext = {
     spaParams:
         | {
               dsfrDirPath_static: string;
-              htmlFilePath: string;
+              // Undefined in Next.js: public/dsfr exists (copy-static-assets put it there)
+              // but there is no index.html to add a cache busting query parameter to.
+              htmlFilePath: string | undefined;
           }
         | undefined;
     isSilent: boolean;
@@ -401,8 +403,6 @@ async function getCommandContext(args: string[]): Promise<CommandContext> {
                 return undefined;
             }
 
-            assert(htmlFilePath !== undefined);
-
             return {
                 dsfrDirPath_static,
                 htmlFilePath
@@ -529,6 +529,40 @@ export async function main(args: string[]) {
             })
     );
 
+    // NOTE: Deliberately outside of the `hasChanged` guard below. The rewrite is
+    // idempotent, and inside the guard a stale or hand reverted hash could never be
+    // repaired as long as icons.min.css itself did not change.
+    await (async function addHashQueryParameterInIndexHtml() {
+        const htmlFilePath = commandContext.spaParams?.htmlFilePath;
+
+        if (htmlFilePath === undefined) {
+            return;
+        }
+
+        const html = (await readFile(htmlFilePath)).toString("utf8");
+
+        const { modifiedHtml } = modifyHtmlHrefs({
+            "html": html,
+            "getModifiedHref": href => {
+                if (!href.includes(iconsMinCssRelativePath.replace(/\\/g, "/"))) {
+                    return href;
+                }
+
+                const [urlWithoutQuery] = href.split("?");
+
+                return `${urlWithoutQuery}?hash=${fnv1aHashToHex(
+                    rawIconCssCodeBuffer.toString("utf8")
+                )}`;
+            }
+        });
+
+        if (modifiedHtml === html) {
+            return;
+        }
+
+        await writeFile(htmlFilePath, Buffer.from(modifiedHtml, "utf8"));
+    })();
+
     if (!hasChanged) {
         log?.("No change since last run");
         return;
@@ -582,33 +616,6 @@ export async function main(args: string[]) {
                         )
                     )
                     .map(([srcFilePath, destFilePath]) => cp(srcFilePath, destFilePath))
-            );
-        })(),
-        (async function addHashQueryParameterInIndexHtml() {
-            if (commandContext.spaParams === undefined) {
-                return;
-            }
-
-            const html = (await readFile(commandContext.spaParams.htmlFilePath)).toString("utf8");
-
-            const { modifiedHtml } = modifyHtmlHrefs({
-                "html": html,
-                "getModifiedHref": href => {
-                    if (!href.includes(iconsMinCssRelativePath.replace(/\\/g, "/"))) {
-                        return href;
-                    }
-
-                    const [urlWithoutQuery] = href.split("?");
-
-                    return `${urlWithoutQuery}?hash=${fnv1aHashToHex(
-                        rawIconCssCodeBuffer.toString("utf8")
-                    )}`;
-                }
-            });
-
-            await writeFile(
-                commandContext.spaParams.htmlFilePath,
-                Buffer.from(modifiedHtml, "utf8")
             );
         })(),
         (async function clearCache() {


### PR DESCRIPTION
# Don't crash `only-include-used-icons` when `public/dsfr` exists without an `index.html`

Spun off from the review of #505 (points 6a and 6b of @lsagetlethias), since the fix belongs to `only-include-used-icons` and is unrelated to that PR.

## Problem

`getCommandContext` builds `spaParams` as soon as `public/dsfr` exists, and asserts an `index.html` alongside it:

https://github.com/codegouvfr/react-dsfr/blob/main/src/bin/only-include-used-icons.ts#L404

The assertion has no message, so when it fires the user gets a bare `AssertionError: Wrong assertion encountered` and no indication of what to do.

It fires whenever `public/dsfr` exists while neither `<projectDir>/index.html` (Vite) nor `<publicDir>/index.html` (CRA) does. Two setups I could reproduce:

- a monorepo invoked as `only-include-used-icons --projectDir apps/web` from the workspace root, where the html file is not where either branch looks;
- a project that used to be a Vite/CRA app and no longer has its `index.html`.

Nothing else in the script needs the html file — it is only used to append a `?hash=` cache busting query parameter — so the run has no reason to abort.

## Changes

- `spaParams.htmlFilePath` becomes `string | undefined`, and `addHashQueryParameterInIndexHtml` returns early when there is nothing to rewrite. The icons are still trimmed and still copied to `public/dsfr`.
- That rewrite moves out of the `hasChanged` early return. It is idempotent, and inside the guard a stale or hand-reverted hash could never be repaired as long as `icons.min.css` itself did not change. It now also skips the write when the html is unchanged, so no needless mtime bump.

## Verification

Monorepo repro above, `public/dsfr/utility/icons` populated, no `index.html`:

- before: `AssertionError: Wrong assertion encountered`, nothing written;
- after: exits 0, `public/dsfr/utility/icons/icons.min.css` trimmed to the 6 used icons, second run prints `No change since last run`.

Full suite passes (75 tests), `yarn build`, eslint and prettier clean.
