### PR TITLE
chore(ci): fix the npm publish job and bump to 1.33.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,8 @@ jobs:
           ref: ${{ github.ref }}
       - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          # npm@latest requires node >=22 since npm 12, keep this in step with the test job
+          node-version: '22'
           registry-url: https://registry.npmjs.org/
       - run: npm install -g npm@latest
       - run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@codegouvfr/react-dsfr",
-    "version": "1.32.5",
+    "version": "1.33.0",
     "description": "French State Design System React integration library",
     "repository": {
         "type": "git",


### PR DESCRIPTION
# Fix the npm publish job and release 1.33.0

Two commits, to be merged **after** #506 so that 1.33.0 carries both.

## 1. The publish job has been broken since npm 12

`publish_on_npm` pins node 20, then runs `npm install -g npm@latest`. npm 12 declares
`engines: {"node": "^22.22.2 || ^24.15.0 || >=26.0.0"}`, so that install fails with
`EBADENGINE` and the job dies before ever reaching `npm publish`:

```
npm error code EBADENGINE
npm error Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

That is why **1.32.5 has a git tag and a GitHub release but never reached npm**: in
[run 30816134336](https://github.com/codegouvfr/react-dsfr/actions/runs/30816134336),
`create_github_release` succeeded and `publish_on_npm` failed, leaving `latest` on 1.32.4.
Any version bump would fail the same way until this is fixed.

The job moves to node 22, which is already what the `test` job uses.

## 2. Bump to 1.33.0

Minor rather than patch: #505 adds a new opt-in CLI command
(`react-dsfr only-include-used-components`) and a new `bin` entry, which is additive
public surface. No breaking change.

The release also carries the two fixes that were tagged 1.32.5 but never published
(#493 Footer `categoryName` as `ReactNode`, #501 SideMenu plain button), and, if merged
after #506, its `only-include-used-icons` fixes.

npm will go 1.32.4 → 1.33.0. The `v1.32.5` tag stays as a release that never shipped;
npm does not require contiguous versions.

## Merge order

#506 first, then this. Merged the other way round, 1.33.0 would ship without #506 and
that fix would need a 1.33.1.
