### PR TITLE
fix(only-include-used-components): guard both maps against silent drift

### DIFF
--- a/src/bin/only-include-used-components.ts
+++ b/src/bin/only-include-used-components.ts
@@ -190,10 +190,28 @@ export const REACT_DSFR_MODULE_TO_DSFR_COMPONENTS: Record<string, DsfrComponentN
 };
 
 /**
+ * The stylesheet a DSFR component ships under `component/<name>/<name>.<ext>`, by order of
+ * preference. Not every component has every variant: `download` for instance only ships
+ * `download.css` and `download.min.css`, no `.main.` ones.
+ */
+export const DSFR_COMPONENT_CSS_FILE_EXTENSIONS = [
+    "main.min.css",
+    "min.css",
+    "main.css",
+    "css"
+] as const;
+
+/**
  * CSS class name prefixes that reveal a direct usage of a DSFR component in the
  * sources (when raw fr-* classes are used without importing the React component).
  * Substring matching is intentional and fail-safe: matching too much only means
  * including a component's CSS that may not be needed.
+ *
+ * A prefix only belongs here if it opens a selector in that component's own stylesheet.
+ * A class that the component merely *styles as a descendant* is not a usage signal: its
+ * base rules live elsewhere (usually in the always included core), so detecting on it
+ * pulls the whole component in for nothing. dsfrComponentDetectionClassPrefixes.test.ts
+ * re-derives this rule against the installed @gouvfr/dsfr.
  */
 export const DSFR_COMPONENT_DETECTION_CLASS_PREFIXES: Record<DsfrComponentName, string[]> = {
     "accordion": ["fr-accordion"],
@@ -206,7 +224,10 @@ export const DSFR_COMPONENT_DETECTION_CLASS_PREFIXES: Record<DsfrComponentName, 
     "checkbox": ["fr-checkbox"],
     "connect": ["fr-connect"],
     "consent": ["fr-consent"],
-    "content": ["fr-content-media", "fr-responsive-img", "fr-responsive-vid"],
+    // NOTE: deliberately not fr-responsive-img / fr-responsive-vid. Their base rules
+    // live in the always included core, and every rule content.css has for them is
+    // scoped under .fr-content-media, which is already the prefix detected here.
+    "content": ["fr-content-media"],
     "download": ["fr-download"],
     "follow": ["fr-follow"],
     "footer": ["fr-footer"],
@@ -878,7 +899,7 @@ export async function main(args: string[]) {
         .filter(dirent => dirent.isDirectory())
         .map(dirent => dirent.name)
         .filter(componentName =>
-            ["main.min.css", "min.css", "main.css", "css"].some(ext =>
+            DSFR_COMPONENT_CSS_FILE_EXTENSIONS.some(ext =>
                 fs.existsSync(
                     pathJoin(
                         commandContext.dsfrDirPath,

--- a/test/runtime/scripts/onlyIncludeUsedComponents/dsfrComponentDetectionClassPrefixes.test.ts
+++ b/test/runtime/scripts/onlyIncludeUsedComponents/dsfrComponentDetectionClassPrefixes.test.ts
@@ -1,0 +1,118 @@
+import { it, expect, describe } from "vitest";
+import * as fs from "fs";
+import { join as pathJoin } from "path";
+import {
+    DSFR_COMPONENT_DETECTION_CLASS_PREFIXES,
+    DSFR_COMPONENT_CSS_FILE_EXTENSIONS
+} from "../../../../src/bin/only-include-used-components";
+
+/**
+ * DSFR_COMPONENT_DETECTION_CLASS_PREFIXES is hand written, and a wrong entry is invisible:
+ * it does not break a build, it just quietly includes a component's CSS in every project
+ * that happens to use the class. This test re-derives it from the installed @gouvfr/dsfr.
+ *
+ * The rule: a prefix earns its place only if it *opens a selector* in that component's own
+ * stylesheet. Merely appearing there is not enough, because a component also styles classes
+ * it does not own: content.css has rules for fr-responsive-img, but all of them are scoped
+ * under `.fr-content-media`, and the base `.fr-responsive-img` rule lives in core, which is
+ * always included. Detecting `content` on fr-responsive-img therefore pulled in ~2.8 KB of
+ * minified CSS for nothing, in every project using that core utility class.
+ *
+ * This is intentionally the one direction that is safe to assert. The opposite check, that
+ * every DSFR class maps back to a component, would be a fail-safe over-inclusion, and the
+ * union of the prefixes is deliberately not exhaustive over the DSFR class vocabulary.
+ */
+describe("DSFR_COMPONENT_DETECTION_CLASS_PREFIXES", () => {
+    const componentsDirPath = pathJoin(
+        process.cwd(),
+        "node_modules",
+        "@gouvfr",
+        "dsfr",
+        "dist",
+        "component"
+    );
+
+    /** Same extension list, in the same order, as the availableDsfrComponents filter. */
+    const getComponentCssFilePath = (componentName: string): string | undefined =>
+        DSFR_COMPONENT_CSS_FILE_EXTENSIONS.map(ext =>
+            pathJoin(componentsDirPath, componentName, `${componentName}.${ext}`)
+        ).find(filePath => fs.existsSync(filePath));
+
+    /**
+     * True when `.<classPrefix>` starts a compound selector, i.e. at the very beginning of
+     * the stylesheet or right after a `,` `{` `}`. Anchoring this way is what separates
+     * `.fr-download {` from `.fr-content-media [class^=fr-responsive-img]`, where the class
+     * only ever appears as a descendant of another component's class.
+     */
+    const doesClassPrefixOpenASelector = (params: {
+        rawCssCode: string;
+        classPrefix: string;
+    }): boolean => {
+        const { rawCssCode, classPrefix } = params;
+
+        return new RegExp(
+            `(?:^|[,{}]\\s*)\\.${classPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+            "m"
+        ).test(rawCssCode);
+    };
+
+    it("only detects on classes each component actually owns", () => {
+        // Deliberately an assertion and not a skip: @gouvfr/dsfr is a direct dependency, so
+        // there is no legitimate case where the stylesheets are absent. Skipping would let
+        // this guard silently evaporate on a future layout change upstream.
+        expect(fs.existsSync(componentsDirPath), `${componentsDirPath} not found`).toBe(true);
+
+        const problems: string[] = [];
+
+        for (const [componentName, classPrefixes] of Object.entries(
+            DSFR_COMPONENT_DETECTION_CLASS_PREFIXES
+        )) {
+            const cssFilePath = getComponentCssFilePath(componentName);
+
+            if (cssFilePath === undefined) {
+                problems.push(`${componentName}: no stylesheet found in ${componentsDirPath}`);
+                continue;
+            }
+
+            const rawCssCode = fs.readFileSync(cssFilePath).toString("utf8");
+
+            for (const classPrefix of classPrefixes) {
+                if (doesClassPrefixOpenASelector({ rawCssCode, classPrefix })) {
+                    continue;
+                }
+
+                problems.push(
+                    `${componentName}: "${classPrefix}" never opens a selector in ${componentName}.css`
+                );
+            }
+        }
+
+        expect(
+            problems,
+            [
+                `These detection prefixes do not identify the component they are mapped to,`,
+                `so matching one pulls in that component's CSS for nothing:`,
+                ...problems.map(entry => `  - ${entry}`),
+                ``,
+                `Either the prefix belongs to another component (or to the always included`,
+                `core), or it is only styled as a descendant. Drop it from`,
+                `DSFR_COMPONENT_DETECTION_CLASS_PREFIXES in`,
+                `src/bin/only-include-used-components.ts.`
+            ].join("\n")
+        ).toStrictEqual([]);
+    });
+
+    it("checks a meaningful number of prefixes", () => {
+        // Guards the loop above: a wrong componentsDirPath, or an upstream rename, would
+        // otherwise leave it iterating over stylesheets it never actually reads.
+        const classPrefixes = Object.values(DSFR_COMPONENT_DETECTION_CLASS_PREFIXES).flat();
+
+        expect(classPrefixes.length).toBeGreaterThan(40);
+
+        expect(
+            Object.keys(DSFR_COMPONENT_DETECTION_CLASS_PREFIXES).filter(
+                componentName => getComponentCssFilePath(componentName) === undefined
+            )
+        ).toStrictEqual([]);
+    });
+});

--- a/test/runtime/scripts/onlyIncludeUsedComponents/publicModuleCoverage.test.ts
+++ b/test/runtime/scripts/onlyIncludeUsedComponents/publicModuleCoverage.test.ts
@@ -1,0 +1,166 @@
+import { it, expect, describe } from "vitest";
+import * as fs from "fs";
+import { join as pathJoin } from "path";
+import {
+    getReactDsfrImportedModuleIds,
+    resolveModuleIdToDsfrComponents
+} from "../../../../src/bin/only-include-used-components";
+
+/**
+ * `only-include-used-components` maps every imported react-dsfr module to the DSFR CSS
+ * components it renders. A module that is in neither REACT_DSFR_MODULE_TO_DSFR_COMPONENTS
+ * nor NON_COMPONENT_MODULE_IDS makes resolveModuleIdToDsfrComponents() return undefined,
+ * which trips the include-everything fail-safe: the script warns and exits 0, so a
+ * consumer importing a component added after the map was written silently stops getting
+ * any CSS trimmed at all. Nothing else in the test suite notices.
+ *
+ * This test is the guard: adding a component to `src/` without adding it to one of the
+ * two maps fails here, naming the module.
+ *
+ * On what counts as a public module: package.json has NO `exports` field (checked below),
+ * so the published subpaths are not an explicit list to compare against. They are exactly
+ * whatever `tsc -p src` emits: the publish job runs denoify's `enable_short_npm_import_path`
+ * (.github/workflows/ci.yaml), which moves the content of the tsconfig `outDir` up one level
+ * onto the package root, so `@codegouvfr/react-dsfr/<subpath>` resolves straight into it.
+ * The enumeration below therefore replays that emission: the entries of `src/`, minus what
+ * `src/tsconfig.json` excludes (read from the file, not hardcoded, so a future exclude stays
+ * in sync) and minus the files tsc does not emit a module for.
+ */
+describe("REACT_DSFR_MODULE_TO_DSFR_COMPONENTS exhaustiveness", () => {
+    const projectRootDirPath = process.cwd();
+    const srcDirPath = pathJoin(projectRootDirPath, "src");
+
+    /**
+     * Top level names excluded from the `tsc -p src` emission, e.g. "bin".
+     * Only the first path segment is kept, so a pattern is still understood if it is ever
+     * widened to a glob ("./bin" and "./bin/**" both yield "bin").
+     */
+    const getSrcTsconfigExcludedNames = (): Set<string> => {
+        const { exclude }: { exclude?: string[] } = JSON.parse(
+            fs.readFileSync(pathJoin(srcDirPath, "tsconfig.json")).toString("utf8")
+        );
+
+        return new Set((exclude ?? []).map(pattern => pattern.replace(/^\.\//, "").split("/")[0]));
+    };
+
+    const isModuleSourceFileName = (fileName: string): boolean =>
+        /\.tsx?$/.test(fileName) && !fileName.endsWith(".d.ts");
+
+    const removeExtension = (fileName: string): string => fileName.replace(/\.tsx?$/, "");
+
+    /**
+     * The `@codegouvfr/react-dsfr/<subpath>` a consumer can import.
+     * A directory with an index is importable as is; one without (Chart, blocks, shared,
+     * tools...) is only reachable through a deeper path, so its direct children are listed
+     * instead. That second case is what produces the two segment "blocks/PasswordInput".
+     */
+    const getPublicSubpaths = (): string[] => {
+        const excludedNames = getSrcTsconfigExcludedNames();
+
+        const subpaths: string[] = [];
+
+        for (const dirent of fs.readdirSync(srcDirPath, { "withFileTypes": true })) {
+            if (excludedNames.has(dirent.name)) {
+                continue;
+            }
+
+            if (!dirent.isDirectory()) {
+                if (isModuleSourceFileName(dirent.name)) {
+                    subpaths.push(removeExtension(dirent.name));
+                }
+                continue;
+            }
+
+            const dirPath = pathJoin(srcDirPath, dirent.name);
+            const childNames = fs.readdirSync(dirPath);
+
+            if (childNames.some(childName => /^index\.tsx?$/.test(childName))) {
+                subpaths.push(dirent.name);
+                continue;
+            }
+
+            for (const childName of childNames) {
+                subpaths.push(`${dirent.name}/${removeExtension(childName)}`);
+            }
+        }
+
+        return subpaths;
+    };
+
+    /**
+     * Goes through the production extraction rather than reimplementing it, so the module
+     * ids asserted here are the ones the script will actually resolve at run time.
+     */
+    const getModuleIdBySubpath = (): Map<string, string[]> =>
+        new Map(
+            getPublicSubpaths().map(subpath => [
+                subpath,
+                getReactDsfrImportedModuleIds({
+                    "rawFileContent": `import "@codegouvfr/react-dsfr/${subpath}";`
+                })
+            ])
+        );
+
+    it("covers every module publicly exposed by src/", () => {
+        // One list, one assertion: every problem found in this run is reported at once.
+        // Asserting inside the loop, or once per category, would abort on the first
+        // offender and hide the rest, turning a single fix-and-rerun cycle into several.
+        const problems: string[] = [];
+
+        for (const [subpath, moduleIds] of getModuleIdBySubpath()) {
+            // A public subpath must yield exactly one module id, otherwise the extraction
+            // dropped it and its coverage would go unchecked, vacuously passing.
+            if (moduleIds.length !== 1) {
+                problems.push(
+                    `src/${subpath}: extraction yielded ${moduleIds.length} module ids, expected 1`
+                );
+                continue;
+            }
+
+            const [moduleId] = moduleIds;
+
+            if (resolveModuleIdToDsfrComponents({ moduleId }) === undefined) {
+                problems.push(`${moduleId} (from src/${subpath}): resolves to undefined`);
+            }
+        }
+
+        expect(
+            problems,
+            [
+                `only-include-used-components would fall back to including every DSFR`,
+                `component because of:`,
+                ...problems.map(entry => `  - ${entry}`),
+                ``,
+                `Add each unresolved module to REACT_DSFR_MODULE_TO_DSFR_COMPONENTS (with the`,
+                `DSFR components its markup renders, transitive dependencies included) or to`,
+                `NON_COMPONENT_MODULE_IDS if it renders no DSFR markup, in`,
+                `src/bin/only-include-used-components.ts.`
+            ].join("\n")
+        ).toStrictEqual([]);
+    });
+
+    it("enumerates the public modules from the real src/ layout", () => {
+        // Guards the enumeration itself: were getPublicSubpaths() to return nothing (a bad
+        // path, a changed layout), the coverage assertion above would pass on an empty set.
+        const subpaths = getPublicSubpaths();
+
+        expect(subpaths.length).toBeGreaterThan(40);
+
+        for (const expected of ["Header", "Highlight", "blocks/PasswordInput", "i18n"]) {
+            expect(subpaths).toContain(expected);
+        }
+
+        // `src/tsconfig.json` excludes `./bin`: the CLI is not a public import subpath.
+        expect(subpaths.some(subpath => subpath.startsWith("bin"))).toBe(false);
+    });
+
+    it("has no package.json exports field to compare against", () => {
+        // The premise of the enumeration above. If an `exports` map is ever added, this
+        // fails and the public subpaths must be read from it instead of from src/.
+        const packageJsonParsed = JSON.parse(
+            fs.readFileSync(pathJoin(projectRootDirPath, "package.json")).toString("utf8")
+        );
+
+        expect(packageJsonParsed["exports"]).toBe(undefined);
+    });
+});

--- a/test/runtime/scripts/onlyIncludeUsedComponents/publicModuleCoverage.test.ts
+++ b/test/runtime/scripts/onlyIncludeUsedComponents/publicModuleCoverage.test.ts
@@ -48,11 +48,20 @@ describe("REACT_DSFR_MODULE_TO_DSFR_COMPONENTS exhaustiveness", () => {
 
     const removeExtension = (fileName: string): string => fileName.replace(/\.tsx?$/, "");
 
+    const hasAnIndex = (dirPath: string): boolean =>
+        fs.readdirSync(dirPath).some(childName => /^index\.tsx?$/.test(childName));
+
     /**
-     * The `@codegouvfr/react-dsfr/<subpath>` a consumer can import.
-     * A directory with an index is importable as is; one without (Chart, blocks, shared,
-     * tools...) is only reachable through a deeper path, so its direct children are listed
-     * instead. That second case is what produces the two segment "blocks/PasswordInput".
+     * The `@codegouvfr/react-dsfr/<subpath>` a consumer can import, one per module the
+     * script has to resolve. Not every importable path: `tools/powerhooks/useConst` is
+     * importable too, but yields the same module id as `tools/cx`, so listing the
+     * shallowest path per module is enough and keeps failure messages readable.
+     *
+     * A directory with an index is importable as is. One without (Chart, blocks, shared,
+     * tools...) is only reachable deeper, so its children are listed instead, which is what
+     * produces the two segment "blocks/PasswordInput". A child directory is importable in
+     * turn only if it has an index of its own: `tools/StatefulObservable` has one,
+     * `tools/powerhooks` does not.
      */
     const getPublicSubpaths = (): string[] => {
         const excludedNames = getSrcTsconfigExcludedNames();
@@ -72,15 +81,21 @@ describe("REACT_DSFR_MODULE_TO_DSFR_COMPONENTS exhaustiveness", () => {
             }
 
             const dirPath = pathJoin(srcDirPath, dirent.name);
-            const childNames = fs.readdirSync(dirPath);
 
-            if (childNames.some(childName => /^index\.tsx?$/.test(childName))) {
+            if (hasAnIndex(dirPath)) {
                 subpaths.push(dirent.name);
                 continue;
             }
 
-            for (const childName of childNames) {
-                subpaths.push(`${dirent.name}/${removeExtension(childName)}`);
+            for (const childDirent of fs.readdirSync(dirPath, { "withFileTypes": true })) {
+                // Files are kept whatever their extension: src/assets holds only .svg and
+                // .css, and skipping those would drop the "assets" module id altogether,
+                // silently leaving it unchecked.
+                if (childDirent.isDirectory() && !hasAnIndex(pathJoin(dirPath, childDirent.name))) {
+                    continue;
+                }
+
+                subpaths.push(`${dirent.name}/${removeExtension(childDirent.name)}`);
             }
         }
 
@@ -140,14 +155,24 @@ describe("REACT_DSFR_MODULE_TO_DSFR_COMPONENTS exhaustiveness", () => {
     });
 
     it("enumerates the public modules from the real src/ layout", () => {
-        // Guards the enumeration itself: were getPublicSubpaths() to return nothing (a bad
-        // path, a changed layout), the coverage assertion above would pass on an empty set.
+        // Guards the enumeration itself: were getPublicSubpaths() to return nothing, or to
+        // quietly stop covering a module, the assertion above would pass on what it no
+        // longer looks at. Narrowing the enumeration has to fail here, not go unnoticed.
         const subpaths = getPublicSubpaths();
 
         expect(subpaths.length).toBeGreaterThan(40);
 
         for (const expected of ["Header", "Highlight", "blocks/PasswordInput", "i18n"]) {
             expect(subpaths).toContain(expected);
+        }
+
+        // One representative per shape: a component directory with an index, a flat file,
+        // index-less directories reached through a child, and a directory whose children
+        // are not TypeScript at all (src/assets holds only .svg and .css).
+        const moduleIds = new Set(Array.from(getModuleIdBySubpath().values()).flat());
+
+        for (const expected of ["Header", "Alert", "Chart", "tools", "shared", "assets"]) {
+            expect(moduleIds).toContain(expected);
         }
 
         // `src/tsconfig.json` excludes `./bin`: the CLI is not a public import subpath.


### PR DESCRIPTION
Closes #514.

Two hand-written maps in `only-include-used-components` had no guard against drift. This adds one test per map and fixes the drift the second test found.

#### Fix: `content` was detected on core utility classes

`fr-responsive-img` and `fr-responsive-vid` were listed as detection prefixes for `content`, but their base rules (and the 7 ratio modifiers) live in `core.main.css`, always included. All 8 occurrences in `content.main.css` are scoped under `.fr-content-media`, none unscoped, so dropping them loses nothing.

Measured end to end, consumer using `fr-responsive-img` without `fr-content-media`: 3 components included instead of 2, `dsfr.min.css` 234 877 B instead of 231 924 B. A consumer that does use `fr-content-media` still gets the component, descendant rules included.

#### Tests

`publicModuleCoverage` enumerates the public subpaths from the real `src/` layout, minus what `src/tsconfig.json` excludes, runs them through the production module id extraction, and asserts each resolves. `dsfrComponentDetectionClassPrefixes` asserts every prefix opens a selector in its own component stylesheet, read from the installed `@gouvfr/dsfr`.

Both were checked against the inputs that make them answer false, not only the nominal ones. Seven mutations, each failing with the offending name: `Highlight` removed from the map; a new component as a flat file, as a directory with an index, and as a directory without one; a new `blocks/*` entry; `fr-responsive-img` reintroduced; a typo'd prefix; a prefix pointing at the wrong component.

#### Verified

`yarn test` (27 files, 108 tests), `tsc -p src/bin`, eslint, prettier, plus the end to end A/B above on a built artifact. Note `src/tsconfig.json` excludes `./bin`, so `tsc -p src` does not cover the changed file; `tsc -p src/bin` does.

#### Scope

The module map is asserted to be complete, not correct. A mapping missing a transitive dependency would under-include and still pass. I probed for that by detecting DSFR classes in each module's own sources: it surfaced 4 candidates, all false positives caused by the `content` bug above. Once that is fixed there is no signal left on that path, and a real guard would need to follow the React import graph. Out of scope here.
