### PR TITLE
feat(BackToTop): add the BackToTop component

### DIFF
--- a/src/BackToTop.tsx
+++ b/src/BackToTop.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React, { forwardRef, memo, type CSSProperties } from "react";
+import type { Equals } from "tsafe";
+import { assert } from "tsafe/assert";
+import { symToStr } from "tsafe/symToStr";
+import { fr } from "./fr";
+import { createComponentI18nApi } from "./i18n";
+import { cx } from "./tools/cx";
+import { useAnalyticsId } from "./tools/useAnalyticsId";
+
+export type BackToTopProps = {
+    id?: string;
+    className?: string;
+    style?: CSSProperties;
+    classes?: Partial<Record<"root" | "link", string>>;
+    /** Default: false (the link is aligned on the left of the content) */
+    right?: boolean;
+} & (BackToTopProps.WithAnchor | BackToTopProps.WithTargetRef);
+
+export namespace BackToTopProps {
+    export type WithAnchor = {
+        /**
+         * Anchor of the element to go back to. Default: `"#top"`.
+         *
+         * The DSFR expects the matching `id` to be set on the topmost element of the
+         * page, `<body id="top">` or the skip links container
+         * (`<div class="fr-skiplinks" id="top">`), so that the navigation focus is
+         * moved back to the top of the page along with the scroll.
+         */
+        anchor?: string;
+        targetRef?: undefined;
+    };
+
+    export type WithTargetRef = {
+        anchor?: undefined;
+        /**
+         * Element to scroll back to, as an alternative to `anchor` when no `id` can be
+         * set on the top of the page. A `<button>` is rendered instead of a link: it
+         * scrolls the element into view and moves the focus onto it.
+         *
+         * Typed structurally rather than as `RefObject<HTMLElement>` so that refs
+         * created by both React 18 and React 19 are accepted.
+         */
+        targetRef: { readonly current: HTMLElement | null };
+    };
+}
+
+/** @see <https://components.react-dsfr.codegouv.studio/?path=/docs/components-backtotop> */
+export const BackToTop = memo(
+    forwardRef<HTMLDivElement, BackToTopProps>((props, ref) => {
+        const {
+            id: id_props,
+            className,
+            style,
+            classes = {},
+            right = false,
+            anchor,
+            targetRef,
+            ...rest
+        } = props;
+
+        assert<Equals<keyof typeof rest, never>>();
+
+        const { t } = useTranslation();
+
+        const id = useAnalyticsId({
+            "defaultIdPrefix": "fr-back-to-top",
+            "explicitlyProvidedId": id_props
+        });
+
+        const linkClassName = cx(
+            fr.cx("fr-link", "fr-link--icon-left", "fr-icon-arrow-up-fill"),
+            classes.link
+        );
+
+        // The wrapper only carries a class when the link is aligned on the right or when
+        // the consumer provides one, `|| undefined` keeps an empty class="" out of the DOM.
+        const rootClassName =
+            cx(right && fr.cx("fr-grid-row", "fr-grid-row--right"), classes.root, className) ||
+            undefined;
+
+        return (
+            <div id={id} ref={ref} style={style} className={rootClassName}>
+                {targetRef === undefined ? (
+                    <a className={linkClassName} href={anchor ?? "#top"}>
+                        {t("back to top")}
+                    </a>
+                ) : (
+                    <button
+                        type="button"
+                        className={linkClassName}
+                        onClick={() => scrollBackTo(targetRef.current)}
+                    >
+                        {t("back to top")}
+                    </button>
+                )}
+            </div>
+        );
+    })
+);
+
+function scrollBackTo(element: HTMLElement | null) {
+    if (element === null) {
+        return;
+    }
+
+    // An anchor gets the focus move for free from the browser, a scripted scroll does
+    // not: without this, keyboard and screen reader users stay where they were while the
+    // viewport jumps. An element that isn't already reachable has to be made
+    // programmatically focusable first.
+    if (element.tabIndex < 0) {
+        element.tabIndex = -1;
+    }
+
+    element.focus({ "preventScroll": true });
+
+    element.scrollIntoView({
+        "behavior": window.matchMedia("(prefers-reduced-motion: reduce)").matches
+            ? "auto"
+            : "smooth",
+        "block": "start"
+    });
+}
+
+BackToTop.displayName = symToStr({ BackToTop });
+
+const { useTranslation, addBackToTopTranslations } = createComponentI18nApi({
+    "componentName": symToStr({ BackToTop }),
+    "frMessages": {
+        /* spell-checker: disable */
+        "back to top": "Haut de page"
+        /* spell-checker: enable */
+    }
+});
+
+addBackToTopTranslations({
+    "lang": "en",
+    "messages": {
+        "back to top": "Back to top"
+    }
+});
+addBackToTopTranslations({
+    "lang": "es",
+    "messages": {
+        "back to top": "Volver arriba"
+    }
+});
+addBackToTopTranslations({
+    "lang": "de",
+    "messages": {
+        "back to top": "Zum Seitenanfang"
+    }
+});
+
+export { addBackToTopTranslations };
+
+export default BackToTop;

--- a/src/BackToTop.tsx
+++ b/src/BackToTop.tsx
@@ -109,18 +109,42 @@ function scrollBackTo(element: HTMLElement | null) {
     // not: without this, keyboard and screen reader users stay where they were while the
     // viewport jumps. An element that isn't already reachable has to be made
     // programmatically focusable first.
-    if (element.tabIndex < 0) {
-        element.tabIndex = -1;
+    //
+    // Three things this shape is deliberate about:
+    // - The attribute goes back on blur, not right after `focus()`. Removing it while the
+    //   element still holds the focus blurs it, which defeats the whole point (measured:
+    //   `document.activeElement` falls back to `<body>` on the same tick).
+    // - The guard tests the attribute and not only `tabIndex`, because an element carrying
+    //   an explicit `tabindex="-1"` also reports -1 and its attribute is not ours to remove.
+    // - Should the blur never come, what is left behind is a `tabindex="-1"`, which by
+    //   definition keeps the element out of the tab order. The failure mode is inert.
+    if (!element.hasAttribute("tabindex") && element.tabIndex < 0) {
+        element.setAttribute("tabindex", "-1");
+        element.addEventListener("blur", () => element.removeAttribute("tabindex"), {
+            "once": true
+        });
     }
 
     element.focus({ "preventScroll": true });
 
-    element.scrollIntoView({
-        "behavior": window.matchMedia("(prefers-reduced-motion: reduce)").matches
-            ? "auto"
-            : "smooth",
-        "block": "start"
-    });
+    if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        element.scrollIntoView({ "behavior": "smooth", "block": "start" });
+
+        return;
+    }
+
+    // `behavior: "auto"` would not do: it means "use the CSS scroll-behavior", so it still
+    // animates on a page that sets `scroll-behavior: smooth`. `"instant"` is absent from
+    // TypeScript 4.9's ScrollBehavior and throws a TypeError on browsers that predate it.
+    // Neutralising the CSS is what the DSFR itself does around its scroll lock.
+    const { documentElement } = document;
+    const inlineScrollBehavior = documentElement.style.scrollBehavior;
+
+    documentElement.style.scrollBehavior = "auto";
+
+    element.scrollIntoView({ "block": "start" });
+
+    documentElement.style.scrollBehavior = inlineScrollBehavior;
 }
 
 BackToTop.displayName = symToStr({ BackToTop });

--- a/src/bin/only-include-css-of-used-components.ts
+++ b/src/bin/only-include-css-of-used-components.ts
@@ -125,6 +125,7 @@ export const REACT_DSFR_MODULE_TO_DSFR_COMPONENTS: Record<string, DsfrComponentN
     "Accordion": ["accordion"],
     "AgentConnectButton": ["connect", "button"],
     "Alert": ["alert", "link", "button"],
+    "BackToTop": ["link"],
     "Badge": ["badge"],
     "Breadcrumb": ["breadcrumb", "link"],
     "Button": ["button", "link"],

--- a/stories/BackToTop.stories.tsx
+++ b/stories/BackToTop.stories.tsx
@@ -1,8 +1,6 @@
-import { BackToTop, type BackToTopProps } from "../dist/BackToTop";
+import { BackToTop } from "../dist/BackToTop";
 import { getStoryFactory } from "./getStory";
 import { sectionName } from "./sectionName";
-import { assert } from "tsafe/assert";
-import type { Equals } from "tsafe";
 
 const { meta, getStory } = getStoryFactory({
     sectionName,
@@ -68,16 +66,3 @@ export const BackToTopOnRight = getStory(
     },
     { "description": "Aligned on the right, wrapped in a `fr-grid-row fr-grid-row--right`." }
 );
-
-export const WithCustomAnchor = getStory(
-    {
-        "anchor": "#header"
-    },
-    { "description": "Pointing to an element other than the top of the page." }
-);
-
-{
-    type ExpectedKeys = "id" | "className" | "style" | "classes" | "right" | "anchor" | "targetRef";
-
-    assert<Equals<keyof BackToTopProps, ExpectedKeys>>();
-}

--- a/stories/BackToTop.stories.tsx
+++ b/stories/BackToTop.stories.tsx
@@ -1,0 +1,83 @@
+import { BackToTop, type BackToTopProps } from "../dist/BackToTop";
+import { getStoryFactory } from "./getStory";
+import { sectionName } from "./sectionName";
+import { assert } from "tsafe/assert";
+import type { Equals } from "tsafe";
+
+const { meta, getStory } = getStoryFactory({
+    sectionName,
+    "wrappedComponent": { BackToTop },
+    "description": `
+- [See DSFR documentation](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/lien#retour-en-haut-de-page)
+- [See source code](https://github.com/codegouvfr/react-dsfr/blob/main/src/BackToTop.tsx)
+
+By default the component renders an anchor pointing to \`#top\`. The DSFR expects the
+matching \`id\` to be set on the topmost element of the page so that the navigation focus
+moves back to the top along with the scroll:
+
+\`\`\`html
+<body id="top">
+\`\`\`
+
+When no \`id\` can be set on the top of the page, pass a \`targetRef\` instead. A
+\`<button>\` is rendered, it scrolls the element into view and moves the focus onto it,
+honouring \`prefers-reduced-motion\`:
+
+\`\`\`tsx
+function Page() {
+    const topRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <div ref={topRef} />
+            {/* ... */}
+            <BackToTop targetRef={topRef} right />
+        </>
+    );
+}
+\`\`\`
+
+\`anchor\` and \`targetRef\` are mutually exclusive.
+`,
+    "argTypes": {
+        "anchor": {
+            "control": { "type": "text" },
+            "description":
+                'Anchor of the element to go back to. Default: `"#top"`. Mutually exclusive with `targetRef`.'
+        },
+        "targetRef": {
+            "control": { "type": null },
+            "description":
+                "Element to scroll back to, as an alternative to `anchor`. Renders a `<button>` instead of a link."
+        },
+        "right": {
+            "control": "boolean",
+            "description": "Align the link on the right of the content. Default: `false`"
+        }
+    },
+    "disabledProps": ["lang"]
+});
+
+export default meta;
+
+export const Default = getStory({});
+
+export const BackToTopOnRight = getStory(
+    {
+        "right": true
+    },
+    { "description": "Aligned on the right, wrapped in a `fr-grid-row fr-grid-row--right`." }
+);
+
+export const WithCustomAnchor = getStory(
+    {
+        "anchor": "#header"
+    },
+    { "description": "Pointing to an element other than the top of the page." }
+);
+
+{
+    type ExpectedKeys = "id" | "className" | "style" | "classes" | "right" | "anchor" | "targetRef";
+
+    assert<Equals<keyof BackToTopProps, ExpectedKeys>>();
+}


### PR DESCRIPTION
Reprise de #139, ouverte par @sylvainlg en juin 2023. Il a confirmé le 31/08 que le travail pouvait être repris (https://github.com/codegouvfr/react-dsfr/pull/139#issuecomment-5475022294). La structure, le nommage des props et les stories viennent de sa PR.

Closes #139

## Ce que la revue de #139 laissait ouvert

La seule remarque non traitée était https://github.com/codegouvfr/react-dsfr/pull/139#discussion_r1226726757, que @garronej avait marquée comme bloquante. Elle demandait trois choses :

1. un scroll fluide vers le haut de page comme comportement par défaut quand aucune ancre n'est fournie ;
2. dans ce cas un `<button>` stylé `fr-link`, parce qu'un `<a>` sans `href` valide n'est pas accessible ;
3. une `ref` plutôt qu'un sélecteur CSS pour désigner la cible, « Dsfr components do not allow to provide html id but all enable to provide ref ».

Les points 2 et 3 sont implémentés tels quels. Le point 1 est implémenté mais **pas en défaut**, et c'est la seule divergence assumée de cette PR.

## API

```tsx
<BackToTop />                        // <a href="#top">, forme canonique DSFR
<BackToTop anchor="#header" />       // ancre explicite
<BackToTop targetRef={topRef} />     // <button>, scroll + focus scriptés
<BackToTop right />                  // aligné à droite
```

`anchor` et `targetRef` sont mutuellement exclusives au niveau du type.

## Pourquoi l'ancre reste le défaut

La doc DSFR est explicite sur ce composant (`src/dsfr/component/link/example/back-to-top/index.ejs` dans le paquet `@gouvfr/dsfr`) :

> Le lien de "retour en haut de page" est une ancre vers un élément dont l'id est "top". Afin de le faire fonctionner correctement, il est nécessaire d'ajouter l'attribut id (`id="top"`) sur l'élément le plus haut de la page comme le body (`<body id="top">`) ou les liens d'évitement (`<div class="fr-skiplinks" id="top">`), **afin que le focus de navigation soit lui aussi replacé en haut de page**.

C'est le point qui tranche : un `window.scrollTo` déplace le viewport mais pas le focus. Vérifié dans un navigateur, sur une page avec `<body id="top">` : le focus posé sur un lien en milieu de page, un clic sur `<a href="#top">` fait passer `document.activeElement` de ce lien à `body#top`. Un scroll scripté ne produit pas ce déplacement.

La variante `targetRef` couvre donc le besoin de #139 sans ce défaut : elle fait `scrollIntoView` **et** `focus({ preventScroll: true })` sur la cible, en posant `tabindex="-1"` si l'élément n'est pas déjà atteignable.

@garronej si tu préfères malgré tout `targetRef` en défaut, ou une prop `smooth` supplémentaire, dis-le et je change.

## prefers-reduced-motion

La première version de cette PR passait `behavior: "auto"` quand `prefers-reduced-motion: reduce` est actif. C'était faux et la description l'annonçait à tort comme réglé. `"auto"` ne veut pas dire « ne pas animer », il veut dire « prends la valeur CSS de `scroll-behavior` » : sur une page qui pose `scroll-behavior: smooth`, l'animation avait lieu quand même.

Mesuré en lisant `scrollTop` de façon synchrone juste après l'appel, sur un conteneur dont la feuille de style pose `scroll-behavior: smooth` — un scroll instantané a déjà atterri, un scroll animé non :

| `behavior` passé | `scroll-behavior` CSS | `scrollTop` avant → après | animé |
|---|---|---|---|
| `"auto"` | `smooth` | 2845 → 2845 | oui |
| `"instant"` | `smooth` | 2845 → 0 | non |
| `"smooth"` | `smooth` | 2845 → 2845 | oui |
| `"auto"` | `auto` | 2863 → 0 | non |

`"instant"` n'est pas le correctif pour autant : il est absent de `ScrollBehavior` dans le `lib.dom.d.ts` de TypeScript 4.9, la version du dépôt, et une valeur d'enum WebIDL inconnue lève un `TypeError`, ce qui casserait le handler après que le focus a déjà bougé. Le CSS est donc neutralisé en inline puis restauré, ce que fait déjà le DSFR autour de son propre scroll lock (`dsfr.module.js`, `ScrollLock.lock`). Corrigé en 125a422.

## Rendu vérifié

Markup obtenu via `renderToStaticMarkup`, à comparer au sample DSFR `link-back-to-top.ejs` (`label: 'Haut de page'`, `href: '#top'`, `icon: 'arrow-up-fill'`, `iconPlace: 'left'`) :

```html
<!-- <BackToTop /> -->
<div id="fr-back-to-top-:R0:"><a class="fr-link fr-link--icon-left fr-icon-arrow-up-fill" href="#top">Haut de page</a></div>

<!-- <BackToTop right /> -->
<div id="fr-back-to-top-:R0:" class="fr-grid-row fr-grid-row--right"><a class="fr-link fr-link--icon-left fr-icon-arrow-up-fill" href="#top">Haut de page</a></div>

<!-- <BackToTop targetRef={topRef} /> -->
<div id="fr-back-to-top-:R0:"><button type="button" class="fr-link fr-link--icon-left fr-icon-arrow-up-fill">Haut de page</button></div>
```

## Optimiseur CSS

`"BackToTop": ["link"]` est ajouté à `REACT_DSFR_MODULE_TO_DSFR_COMPONENTS`. Vérifié de bout en bout avec `npx react-dsfr optimize-css` sur un projet jetable qui n'importe que `BackToTop` :

```
Found fr-icon-arrow-up-fill in node_modules/@codegouvfr/react-dsfr/BackToTop.js
Found import of BackToTop in src/App.tsx
Including the CSS of 1 DSFR components (out of 45).
```

`dsfr.min.css` tombe à 200 664 octets, `fr-link` conservé, `fr-table` et `fr-accordion` absents. Sans l'entrée dans la map, le même projet donne :

```
[react-dsfr] Unknown react-dsfr module "BackToTop" imported in src/App.tsx: no CSS is trimmed at all for this run, every component is included.
Including the CSS of 45 DSFR components (out of 45).
```

soit 591 050 octets. L'entrée vaut donc 390 ko de CSS sur ce projet, et son absence est bien le fail-safe. Le test `publicModuleCoverage` échoue également en nommant `BackToTop (from src/BackToTop): resolves to undefined`.

L'icône n'est pas rognée non plus : `npm pack @codegouvfr/react-dsfr@1.33.0` montre que le paquet publié embarque `src/` (386 fichiers), et le scanner d'icônes descend dans `node_modules/@codegouvfr/react-dsfr/src`, où le littéral `fr-icon-arrow-up-fill` est présent.

## Vérifications lancées

| Commande | Résultat |
|---|---|
| `yarn build` | OK |
| `tsc -p src --noEmit` | OK |
| `tsc -p src/bin --noEmit` | OK (`src/tsconfig.json` exclut `./bin`, donc couvert séparément) |
| `yarn test` | 27 fichiers, 108 tests |
| `yarn format:check` | OK |
| `eslint` sur les fichiers touchés | OK |
| `npx react-dsfr optimize-css` sur projet jetable | 1 composant sur 45 |

## Limites

- **Le retrait du `tabindex` au blur n'est pas vérifié.** Le composant pose `tabindex="-1"` sur la cible si elle n'est pas déjà atteignable, et le retire sur `blur`. Retirer l'attribut juste après `focus()` ne marche pas, c'est mesuré : l'élément est blurré et `document.activeElement` retombe sur `<body>`. Le `blur` lui-même n'a pas pu être testé, l'environnement de test ne dispatche aucun événement de focus (`document.hasFocus()` est `false`). Si le blur ne vient jamais, ce qui reste est un `tabindex="-1"`, qui par définition garde l'élément hors de l'ordre de tabulation : le mode dégradé est inerte.
- Pas de story live pour `targetRef` : `getStory` ne passe que des props sérialisables au composant, donc la variante est documentée par un bloc de code dans la description, comme le fait déjà `Accordion` pour son mode contrôlé.
- Pas de test unitaire : le dépôt n'a aucune infra de rendu (ni `jsdom` ni `@testing-library/react`). Le markup ci-dessus a été vérifié via `react-dom/server` dans un fichier jetable, et `scrollBackTo` dans un navigateur en injectant la fonction telle que compilée dans `dist/BackToTop.js`.
