### PR TITLE
fix(Table): Remove non-color variants from colorVariants

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -31,7 +31,14 @@ export namespace TableProps {
     type ExtractColorVariant<FrClassName> = FrClassName extends `fr-table--${infer AccentColor}`
         ? Exclude<
               AccentColor,
-              "no-scroll" | "no-caption" | "caption-bottom" | "layout-fixed" | "bordered"
+              | "no-scroll"
+              | "no-caption"
+              | "caption-bottom"
+              | "layout-fixed"
+              | "bordered"
+              | "multiline"
+              | "sm"
+              | "lg"
           >
         : never;
 


### PR DESCRIPTION
Namely "sm", "lg" and "multiline"